### PR TITLE
NN-3894: Dummy offence details pages

### DIFF
--- a/server/routes/detailsOfOffence/detailsOfOffence.test.ts
+++ b/server/routes/detailsOfOffence/detailsOfOffence.test.ts
@@ -1,0 +1,27 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes from '../testutils/appSetup'
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({ production: false })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /details-of-offence', () => {
+  it('should load the type of offence page', () => {
+    return request(app)
+      .get('/details-of-offence/G6415GD/3456')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Offence details')
+        expect(res.text).toContain(
+          '<a href="/incident-statement/G6415GD/3456" class="govuk-link">Go to incident statement page</a>'
+        )
+      })
+  })
+})

--- a/server/routes/detailsOfOffence/detailsOfOffence.ts
+++ b/server/routes/detailsOfOffence/detailsOfOffence.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express'
+
+export default class DetailsOfOffenceRoutes {
+  private renderView = async (req: Request, res: Response): Promise<void> => {
+    const { prisonerNumber, id } = req.params
+    return res.render(`pages/detailsOfOffence`, {
+      prisonerNumber,
+      id,
+    })
+  }
+
+  view = async (req: Request, res: Response): Promise<void> => this.renderView(req, res)
+}

--- a/server/routes/detailsOfOffence/index.ts
+++ b/server/routes/detailsOfOffence/index.ts
@@ -1,0 +1,16 @@
+import express, { RequestHandler, Router } from 'express'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+import DetailsOfOffenceRoutes from './detailsOfOffence'
+
+export default function detailsOfOffenceRoutes(): Router {
+  const router = express.Router()
+
+  const detailsOfOffence = new DetailsOfOffenceRoutes()
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+
+  get('/:prisonerNumber/:id', detailsOfOffence.view)
+
+  return router
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,6 +2,8 @@ import type { Router } from 'express'
 
 import incidentStatementRoutes from './incidentStatement'
 import incidentDetailsRoutes from './incidentDetails'
+import typeOfOffenceRoutes from './typeOfOffence'
+import detailsOfOffenceRoutes from './detailsOfOffence'
 import checkYourAnswersRoutes from './checkYourAnswers'
 import confirmedOnReportRoutes from './confirmedOnReport'
 import taskListRoutes from './taskList'
@@ -22,6 +24,8 @@ export default function routes(
   { placeOnReportService, locationService, prisonerSearchService, reportedAdjudicationsService, userService }: Services
 ): Router {
   router.use('/incident-details', incidentDetailsRoutes({ placeOnReportService, locationService }))
+  router.use('/offence-details', typeOfOffenceRoutes())
+  router.use('/details-of-offence', detailsOfOffenceRoutes())
   router.use('/incident-statement', incidentStatementRoutes({ placeOnReportService }))
   router.use('/check-your-answers', checkYourAnswersRoutes({ placeOnReportService, locationService }))
   router.use('/prisoner-placed-on-report', confirmedOnReportRoutes({ reportedAdjudicationsService }))

--- a/server/routes/typeOfOffence/index.ts
+++ b/server/routes/typeOfOffence/index.ts
@@ -1,0 +1,16 @@
+import express, { RequestHandler, Router } from 'express'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+import TypeOfOffenceRoutes from './typeOfOffence'
+
+export default function typeOfOffenceRoutes(): Router {
+  const router = express.Router()
+
+  const typeOfOffence = new TypeOfOffenceRoutes()
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+
+  get('/:prisonerNumber/:id', typeOfOffence.view)
+
+  return router
+}

--- a/server/routes/typeOfOffence/typeOfOffence.test.ts
+++ b/server/routes/typeOfOffence/typeOfOffence.test.ts
@@ -1,0 +1,28 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes from '../testutils/appSetup'
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({ production: false })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /offence-details', () => {
+  it('should load the type of offence page', () => {
+    return request(app)
+      .get('/offence-details/G6415GD/3456')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Type of offence')
+        expect(res.text).toContain('Go to offence details page')
+        expect(res.text).toContain(
+          '<a href="/details-of-offence/G6415GD/3456" class="govuk-link">Go to offence details page</a>'
+        )
+      })
+  })
+})

--- a/server/routes/typeOfOffence/typeOfOffence.ts
+++ b/server/routes/typeOfOffence/typeOfOffence.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express'
+
+export default class OffenceDetailsRoutes {
+  private renderView = async (req: Request, res: Response): Promise<void> => {
+    const { prisonerNumber, id } = req.params
+    return res.render(`pages/offenceDetails`, {
+      prisonerNumber,
+      id,
+    })
+  }
+
+  view = async (req: Request, res: Response): Promise<void> => this.renderView(req, res)
+}

--- a/server/routes/typeOfOffence/typeOfOffence.ts
+++ b/server/routes/typeOfOffence/typeOfOffence.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express'
 export default class OffenceDetailsRoutes {
   private renderView = async (req: Request, res: Response): Promise<void> => {
     const { prisonerNumber, id } = req.params
-    return res.render(`pages/offenceDetails`, {
+    return res.render(`pages/typeOfOffence`, {
       prisonerNumber,
       id,
     })

--- a/server/views/pages/detailsOfOffence.njk
+++ b/server/views/pages/detailsOfOffence.njk
@@ -1,0 +1,25 @@
+{% extends "../partials/layout.njk" %}
+
+{% set title = "Offence details" %}
+
+{% block pageTitle %}
+	{{ title }}
+{% endblock %}
+
+{% block content %}
+	{% if errors | length %}
+		{{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors,
+      attributes: { "data-qa": "error-summary" }
+    }) }}
+	{% endif %}
+
+    <h1 class="govuk-heading-l">{{ title }}</h1>
+
+    <p class="govuk-body">
+        <a href="/incident-statement/{{ prisonerNumber }}/{{ id }}" class="govuk-link">Go to incident statement page</a>
+    </p>
+
+
+{% endblock %}

--- a/server/views/pages/typeOfOffence.njk
+++ b/server/views/pages/typeOfOffence.njk
@@ -1,0 +1,25 @@
+{% extends "../partials/layout.njk" %}
+
+{% set title = "Type of offence" %}
+
+{% block pageTitle %}
+	{{ title }}
+{% endblock %}
+
+{% block content %}
+	{% if errors | length %}
+		{{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors,
+      attributes: { "data-qa": "error-summary" }
+    }) }}
+	{% endif %}
+
+    <h1 class="govuk-heading-l">{{ title }}</h1>
+
+    <p class="govuk-body">
+        <a href="/details-of-offence/{{ prisonerNumber }}/{{ id }}" class="govuk-link">Go to offence details page</a>
+    </p>
+
+
+{% endblock %}


### PR DESCRIPTION
Confusingly, we have two different pages with similar names and URLS so I've chosen to avoid using the terms when naming files and instead use the page H1s to identify.
"Type of offence" page - `/offence-details/<prn>/<draft-id>`
"Offence details" page - `/details-of-offence/<prn>/<draft-id>`