### PR TITLE
NN-3895: Cater for API updates to include incident role

### DIFF
--- a/server/data/DraftAdjudicationResult.ts
+++ b/server/data/DraftAdjudicationResult.ts
@@ -4,6 +4,11 @@ export type IncidentDetails = {
   handoverDeadline?: string
 }
 
+export type IncidentRole = {
+  roleCode?: string
+  associatedPrisonersNumber?: string
+}
+
 export type IncidentStatement = {
   statement: string
   completed?: boolean
@@ -15,6 +20,7 @@ export type DraftAdjudication = {
   prisonerNumber: string
   startedByUserId: string
   incidentDetails: IncidentDetails
+  incidentRole: IncidentRole
   incidentStatement?: IncidentStatement
 }
 
@@ -45,6 +51,7 @@ type SummarySectionItems = {
 export type EditedIncidentDetails = {
   dateTimeOfIncident: string
   locationId: number
+  incidentRole?: IncidentRole
 }
 
 export type TaskListDetails = {

--- a/server/data/manageAdjudicationsClient.test.ts
+++ b/server/data/manageAdjudicationsClient.test.ts
@@ -29,12 +29,20 @@ describe('manageAdjudicationsClient', () => {
             locationId: 2,
             dateTimeOfIncident: '2021-10-28T15:40:25.884',
           },
+          incidentRole: {
+            roleCode: '25a',
+            associatedPrisonersNumber: 'B2345BB',
+          },
         },
       }
       const details = {
         locationId: 2,
         agencyId: 'MDI',
         dateTimeOfIncident: '2021-10-28T15:40:25.884',
+        incidentRole: {
+          roleCode: '25a',
+          associatedPrisonersNumber: 'B2345BB',
+        },
         prisonerNumber: 'G2996UX',
       }
 
@@ -49,6 +57,8 @@ describe('manageAdjudicationsClient', () => {
       expect(response.draftAdjudication.prisonerNumber).toEqual('G2996UX')
       expect(response.draftAdjudication.incidentDetails.dateTimeOfIncident).toEqual('2021-10-28T15:40:25.884')
       expect(response.draftAdjudication.incidentDetails.locationId).toEqual(2)
+      expect(response.draftAdjudication.incidentRole.roleCode).toEqual('25a')
+      expect(response.draftAdjudication.incidentRole.associatedPrisonersNumber).toEqual('B2345BB')
     })
   })
 
@@ -61,6 +71,10 @@ describe('manageAdjudicationsClient', () => {
           incidentDetails: {
             locationId: 2,
             dateTimeOfIncident: '2020-12-10T10:00:00',
+          },
+          incidentRole: {
+            roleCode: '25a',
+            associatedPrisonersNumber: 'B2345BB',
           },
           incidentStatement: {
             statement: 'test',
@@ -94,6 +108,10 @@ describe('manageAdjudicationsClient', () => {
             locationId: 2,
             dateTimeOfIncident: '2020-12-10T10:00:00',
           },
+          incidentRole: {
+            roleCode: '25a',
+            associatedPrisonersNumber: 'B2345BB',
+          },
           incidentStatement: {
             statement: 'test',
           },
@@ -121,6 +139,10 @@ describe('manageAdjudicationsClient', () => {
             locationId: 26152,
             dateTimeOfIncident: '2021-11-04T07:20:00',
           },
+          incidentRole: {
+            roleCode: '25a',
+            associatedPrisonersNumber: 'B2345BB',
+          },
           incidentStatement: {
             id: 9,
             statement: 'test',
@@ -147,6 +169,7 @@ describe('manageAdjudicationsClient', () => {
         prisonerNumber: 'G6123VU',
         dateTimeReportExpires: '2021-11-06T09:21:00.00',
         incidentDetails: {},
+        incidentRole: {},
         incidentStatement: {},
       },
     }
@@ -167,6 +190,7 @@ describe('manageAdjudicationsClient', () => {
         adjudicationNumber: 2345221,
         prisonerNumber: 'G6123VU',
         incidentDetails: {},
+        incidentRole: {},
         incidentStatement: {},
       },
     }
@@ -174,6 +198,10 @@ describe('manageAdjudicationsClient', () => {
     const editedDetails = {
       dateTimeOfIncident: '2021-11-04T09:21:00.00',
       locationId: 23424,
+      incidentRole: {
+        roleCode: '25a',
+        associatedPrisonersNumber: 'B2345BB',
+      },
     }
     it('should return a draft adjudication', async () => {
       fakeManageAdjudicationsApi
@@ -196,6 +224,10 @@ describe('manageAdjudicationsClient', () => {
             dateTimeOfIncident: '2021-11-16T14:15:08.021Z',
             locationId: 23444,
           },
+          incidentRole: {
+            roleCode: '25a',
+            associatedPrisonersNumber: 'B2345BB',
+          },
           incidentStatement: {
             completed: true,
             statement: 'string',
@@ -209,6 +241,7 @@ describe('manageAdjudicationsClient', () => {
             dateTimeOfIncident: '2021-11-16T12:30:00.000Z',
             locationId: 1335,
           },
+          incidentRole: {},
           prisonerNumber: 'G2296UP',
         },
       ],
@@ -234,6 +267,10 @@ describe('manageAdjudicationsClient', () => {
           locationId: 3,
           dateTimeOfIncident: '2021-11-15T11:45:00',
         },
+        incidentRole: {
+          roleCode: '25a',
+          associatedPrisonersNumber: 'B2345BB',
+        },
         incidentStatement: {
           statement: 'My second incident',
         },
@@ -247,6 +284,7 @@ describe('manageAdjudicationsClient', () => {
           locationId: 3,
           dateTimeOfIncident: '2021-11-15T11:30:00',
         },
+        incidentRole: {},
         incidentStatement: {
           statement: 'My first incident',
         },
@@ -285,6 +323,10 @@ describe('manageAdjudicationsClient', () => {
           locationId: 3,
           dateTimeOfIncident: '2021-11-15T11:45:00',
         },
+        incidentRole: {
+          roleCode: '25a',
+          associatedPrisonersNumber: 'B2345BB',
+        },
         incidentStatement: {
           statement: 'My second incident',
         },
@@ -298,6 +340,7 @@ describe('manageAdjudicationsClient', () => {
           locationId: 3,
           dateTimeOfIncident: '2021-11-15T11:30:00',
         },
+        incidentRole: {},
         incidentStatement: {
           statement: 'My first incident',
         },
@@ -335,6 +378,10 @@ describe('manageAdjudicationsClient', () => {
             dateTimeOfIncident: '2021-12-01T09:40:00',
             handoverDeadline: '2021-12-03T09:40:00',
           },
+          incidentRole: {
+            roleCode: '25a',
+            associatedPrisonersNumber: 'B2345BB',
+          },
           incidentStatement: {
             statement: 'TESTING',
             completed: true,
@@ -352,8 +399,10 @@ describe('manageAdjudicationsClient', () => {
       expect(response).toEqual(result)
       expect(response.draftAdjudication.prisonerNumber).toEqual('A7820DY')
       expect(response.draftAdjudication.incidentDetails.dateTimeOfIncident).toEqual('2021-12-01T09:40:00')
-      expect(response.draftAdjudication.incidentStatement.statement).toEqual('TESTING')
       expect(response.draftAdjudication.incidentDetails.locationId).toEqual(26142)
+      expect(response.draftAdjudication.incidentRole.roleCode).toEqual('25a')
+      expect(response.draftAdjudication.incidentRole.associatedPrisonersNumber).toEqual('B2345BB')
+      expect(response.draftAdjudication.incidentStatement.statement).toEqual('TESTING')
     })
   })
 })

--- a/server/data/manageAdjudicationsClient.ts
+++ b/server/data/manageAdjudicationsClient.ts
@@ -5,6 +5,7 @@ import {
   IncidentStatement,
   IncidentDetails,
   EditedIncidentDetails,
+  IncidentRole,
 } from './DraftAdjudicationResult'
 import { ReportedAdjudicationResult, ReportedAdjudication } from './ReportedAdjudicationResult'
 import { ApiPageRequest, ApiPageResponse } from './ApiData'
@@ -13,6 +14,7 @@ import RestClient from './restClient'
 export interface IncidentDetailsEnhanced extends IncidentDetails {
   prisonerNumber: string
   agencyId: string
+  incidentRole: IncidentRole
 }
 
 export default class ManageAdjudicationsClient {

--- a/server/routes/continueReport/continueReportSelect.test.ts
+++ b/server/routes/continueReport/continueReportSelect.test.ts
@@ -45,6 +45,7 @@ describe('GET /select-report', () => {
             locationId: 357591,
             dateTimeOfIncident: '2021-10-12T20:00:00',
           },
+          incidentRole: {},
           incidentStatement: {
             statement: 'This is my statement',
             completed: false,
@@ -62,6 +63,7 @@ describe('GET /select-report', () => {
             locationId: 27187,
             dateTimeOfIncident: '2021-11-11T15:15:00',
           },
+          incidentRole: {},
           incidentStatement: {
             statement: 'Test statement',
             completed: true,

--- a/server/routes/incidentDetails/incidentDetails.test.ts
+++ b/server/routes/incidentDetails/incidentDetails.test.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
         locationId: 2,
         dateTimeOfIncident: '2021-10-27T13:30:00.000',
       },
+      incidentRole: {},
     },
   })
   placeOnReportService.getReporterName.mockResolvedValue('Test User')

--- a/server/routes/incidentDetails/incidentDetailsEdit.test.ts
+++ b/server/routes/incidentDetails/incidentDetailsEdit.test.ts
@@ -46,6 +46,7 @@ beforeEach(() => {
         dateTimeOfIncident: '2021-10-27T13:30:17.808Z',
         locationId: 2,
       },
+      incidentRole: {},
       prisonerNumber: 'G6415GD',
     },
   })
@@ -118,6 +119,7 @@ describe('Incident details completed already', () => {
           dateTimeOfIncident: '2021-10-27T13:30:17.808Z',
           locationId: 2,
         },
+        incidentRole: {},
         incidentStatement: {
           completed: true,
           statement: 'blah blah',

--- a/server/routes/incidentDetails/incidentDetailsSubmittedEdit.test.ts
+++ b/server/routes/incidentDetails/incidentDetailsSubmittedEdit.test.ts
@@ -48,6 +48,7 @@ beforeEach(() => {
         dateTimeOfIncident: '2021-10-27T13:30:17.808Z',
         locationId: 2,
       },
+      incidentRole: {},
       prisonerNumber: 'G6415GD',
     },
   })

--- a/server/routes/incidentStatement/incidentStatement.test.ts
+++ b/server/routes/incidentStatement/incidentStatement.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
         dateTimeOfIncident: '2021-12-09T10:30:00',
         handoverDeadline: '2021-12-11T10:30:00',
       },
+      incidentRole: {},
       incidentStatement: {
         statement: 'This is the statement about the event',
         completed: true,

--- a/server/routes/incidentStatement/incidentStatementSubmittedEdit.test.ts
+++ b/server/routes/incidentStatement/incidentStatementSubmittedEdit.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
         dateTimeOfIncident: '2021-12-09T10:30:00',
         handoverDeadline: '2021-12-11T10:30:00',
       },
+      incidentRole: {},
       incidentStatement: {
         statement: 'This is the statement about the event',
         completed: true,

--- a/server/services/placeOnReportService.test.ts
+++ b/server/services/placeOnReportService.test.ts
@@ -76,6 +76,10 @@ describe('placeOnReportService', () => {
         locationId: 3,
         prisonerNumber: 'G2996UX',
         agencyId: 'MDI',
+        // Added by temporary code to preserve APi compatibility
+        incidentRole: {
+          roleCode: '25a',
+        },
       })
       expect(result).toEqual({
         draftAdjudication: {

--- a/server/services/placeOnReportService.ts
+++ b/server/services/placeOnReportService.ts
@@ -77,6 +77,10 @@ export default class PlaceOnReportService {
       agencyId: user.activeCaseLoadId,
       locationId,
       prisonerNumber,
+      // Temporary code to make it work with the current API - all incidents will be "attempted to commit"
+      incidentRole: {
+        roleCode: '25a',
+      },
     }
     return client.startNewDraftAdjudication(requestBody)
   }


### PR DESCRIPTION
This requires temporary code to set the incident role when creating the adjudication.

The rest of the code is to update the API client to match the API changes, and add to tests 