### PR TITLE
NN-4358: Improved fix for going to offence details page from incident role

### DIFF
--- a/integration_tests/integration/incidentRoleSubmittedEdit.cy.ts
+++ b/integration_tests/integration/incidentRoleSubmittedEdit.cy.ts
@@ -31,6 +31,16 @@ context('Incident role (edit after completion of report)', () => {
             dateTimeOfIncident: '2021-11-03T13:10:00',
             locationId: 27029,
           },
+          offenceDetails: [
+            {
+              offenceCode: 1001,
+              offenceRule: {
+                paragraphNumber: '1',
+                paragraphDescription: 'Commits any assault',
+              },
+              victimPrisonersNumber: 'G5512G',
+            },
+          ],
           incidentStatement: {
             completed: true,
             statement: 'Statement here',

--- a/integration_tests/integration/offenceDetailsJourney.cy.ts
+++ b/integration_tests/integration/offenceDetailsJourney.cy.ts
@@ -1,0 +1,93 @@
+import { DraftAdjudication } from '../../server/data/DraftAdjudicationResult'
+import adjudicationUrls from '../../server/utils/urlGenerator'
+import AgeOfPrisoner from '../pages/ageofPrisoner'
+import IncidentRole from '../pages/incidentRole'
+import Page from '../pages/page'
+
+const draftAdjudicationForCommittedYouthOffences: DraftAdjudication = {
+  id: 3456,
+  prisonerNumber: 'G6415GD',
+  incidentDetails: {
+    dateTimeOfIncident: '2021-11-03T11:09:00',
+    handoverDeadline: '2021-11-05T11:09:00',
+    locationId: 234,
+  },
+  isYouthOffender: true,
+  incidentRole: {
+    roleCode: null,
+  },
+  offenceDetails: [
+    {
+      offenceCode: 1001,
+      offenceRule: {
+        paragraphNumber: '1',
+        paragraphDescription: 'Commits any assault',
+      },
+      victimPrisonersNumber: 'G5512G',
+    },
+  ],
+  startedByUserId: 'TEST_GEN',
+}
+
+context('Existing draft adjudication', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.task('stubGetPrisonerDetails', {
+      prisonerNumber: 'G6415GD',
+      response: {
+        offenderNo: 'G6415GD',
+        firstName: 'JOHN',
+        lastName: 'SMITH',
+        assignedLivingUnit: { description: '1-2-015', agencyName: 'Moorland (HMPYOI)', agencyId: 'MDI' },
+        dateOfBirth: '1990-10-11',
+      },
+    })
+    cy.task('stubSaveYouthOffenderStatus', {
+      adjudicationNumber: '3456',
+      response: {
+        draftAdjudication: draftAdjudicationForCommittedYouthOffences,
+      },
+    })
+    cy.task('stubUpdateDraftIncidentRole', {
+      id: 3456,
+      response: {
+        draftAdjudication: draftAdjudicationForCommittedYouthOffences,
+      },
+    })
+    cy.task('stubGetDraftAdjudication', {
+      id: 3456,
+      response: {
+        draftAdjudication: draftAdjudicationForCommittedYouthOffences,
+      },
+    })
+    cy.signIn()
+  })
+
+  it('should go to the offence details page via the role and rule page - standard url', () => {
+    cy.visit(adjudicationUrls.ageOfPrisoner.urls.start(3456))
+    const AgeOfPrisonerPage: AgeOfPrisoner = Page.verifyOnPage(AgeOfPrisoner)
+    AgeOfPrisonerPage.radioAdult().click()
+    AgeOfPrisonerPage.submitButton().click()
+    const incidentRolePage: IncidentRole = Page.verifyOnPage(IncidentRole)
+    incidentRolePage.radioButtons().find('input[value="committed"]').check()
+    incidentRolePage.submitButton().click()
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq(adjudicationUrls.detailsOfOffence.urls.start(3456))
+    })
+  })
+
+  it('should go to the offence selection page via the role and rule page - url for resetting offences', () => {
+    cy.visit(adjudicationUrls.ageOfPrisoner.urls.startWithResettingOffences(3456))
+    const AgeOfPrisonerPage: AgeOfPrisoner = Page.verifyOnPage(AgeOfPrisoner)
+    AgeOfPrisonerPage.radioAdult().click()
+    AgeOfPrisonerPage.submitButton().click()
+    const incidentRolePage: IncidentRole = Page.verifyOnPage(IncidentRole)
+    incidentRolePage.radioButtons().find('input[value="committed"]').check()
+    incidentRolePage.submitButton().click()
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq(adjudicationUrls.offenceCodeSelection.urls.question(3456, 'committed', '1'))
+    })
+  })
+})

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -22,6 +22,7 @@ declare module 'express-session' {
     sessionDecisionForm: DecisionForm
     offenceData: { [key: string]; offenceData?: OffenceData }
     offences: { [key: string]; offences?: Array<OffenceData> }
+    forceOffenceSelection: boolean
   }
 }
 

--- a/server/routes/ageOfPrisoner/ageOfPrisoner.test.ts
+++ b/server/routes/ageOfPrisoner/ageOfPrisoner.test.ts
@@ -3,15 +3,17 @@ import request from 'supertest'
 import appWithAllRoutes from '../testutils/appSetup'
 import PlaceOnReportService from '../../services/placeOnReportService'
 import adjudicationUrls from '../../utils/urlGenerator'
+import AllOffencesSessionService from '../../services/allOffencesSessionService'
 
 jest.mock('../../services/placeOnReportService.ts')
 
 const placeOnReportService = new PlaceOnReportService(null) as jest.Mocked<PlaceOnReportService>
+const allOffencesSessionService = new AllOffencesSessionService() as jest.Mocked<AllOffencesSessionService>
 
 let app: Express
 
 beforeEach(() => {
-  app = appWithAllRoutes({ production: false }, { placeOnReportService })
+  app = appWithAllRoutes({ production: false }, { placeOnReportService, allOffencesSessionService })
   placeOnReportService.getPrisonerDetailsFromAdjNumber.mockResolvedValue({
     offenderNo: 'A7937DY',
     firstName: 'UDFSANAYE',

--- a/server/routes/ageOfPrisoner/ageOfPrisoner.ts
+++ b/server/routes/ageOfPrisoner/ageOfPrisoner.ts
@@ -1,12 +1,13 @@
 import { Request, Response } from 'express'
+import AllOffencesSessionService from '../../services/allOffencesSessionService'
 import PlaceOnReportService from '../../services/placeOnReportService'
 import AgeOfPrisonerPage, { PageRequestType } from './ageOfPrisonerPage'
 
 export default class AgeOfPrisonerRoutes {
   page: AgeOfPrisonerPage
 
-  constructor(placeOnReportService: PlaceOnReportService) {
-    this.page = new AgeOfPrisonerPage(PageRequestType.CREATION, placeOnReportService)
+  constructor(placeOnReportService: PlaceOnReportService, allOffencesSessionService: AllOffencesSessionService) {
+    this.page = new AgeOfPrisonerPage(PageRequestType.CREATION, placeOnReportService, allOffencesSessionService)
   }
 
   view = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/ageOfPrisoner/ageOfPrisonerPage.ts
+++ b/server/routes/ageOfPrisoner/ageOfPrisonerPage.ts
@@ -52,7 +52,7 @@ export default class AgeOfPrisonerPage {
   constructor(
     pageType: PageRequestType,
     private readonly placeOnReportService: PlaceOnReportService,
-    private readonly allOffencesSessionService: AllOffencesSessionService,
+    private readonly allOffencesSessionService: AllOffencesSessionService
   ) {
     this.pageOptions = new PageOptions(pageType)
   }
@@ -80,7 +80,7 @@ export default class AgeOfPrisonerPage {
 
   view = async (req: Request, res: Response): Promise<void> => {
     const adjudicationNumber = Number(req.params.adjudicationNumber)
-    if (!!req.query.reselectingFirstOffence) {
+    if (req.query.reselectingFirstOffence) {
       req.session.forceOffenceSelection = true
     } else {
       delete req.session.forceOffenceSelection
@@ -107,7 +107,7 @@ export default class AgeOfPrisonerPage {
     } catch (postError) {
       logger.error(`Failed to post prison rule for draft adjudication: ${postError}`)
       res.locals.redirectUrl = adjudicationUrls.ageOfPrisoner.urls.start(idValue)
-      if (!!req.query.reselectingFirstOffence) {
+      if (req.query.reselectingFirstOffence) {
         res.locals.redirectUrl = adjudicationUrls.ageOfPrisoner.urls.startWithResettingOffences(idValue)
       }
       throw postError

--- a/server/routes/ageOfPrisoner/ageOfPrisonerSubmittedEdit.ts
+++ b/server/routes/ageOfPrisoner/ageOfPrisonerSubmittedEdit.ts
@@ -1,12 +1,13 @@
 import { Request, Response } from 'express'
+import AllOffencesSessionService from '../../services/allOffencesSessionService'
 import PlaceOnReportService from '../../services/placeOnReportService'
 import AgeOfPrisonerPage, { PageRequestType } from './ageOfPrisonerPage'
 
 export default class AgeOfPrisonerEditSubmittedRoutes {
   page: AgeOfPrisonerPage
 
-  constructor(placeOnReportService: PlaceOnReportService) {
-    this.page = new AgeOfPrisonerPage(PageRequestType.EDIT_SUBMITTED, placeOnReportService)
+  constructor(placeOnReportService: PlaceOnReportService, allOffencesSessionService: AllOffencesSessionService) {
+    this.page = new AgeOfPrisonerPage(PageRequestType.EDIT_SUBMITTED, placeOnReportService, allOffencesSessionService)
   }
 
   view = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/ageOfPrisoner/index.ts
+++ b/server/routes/ageOfPrisoner/index.ts
@@ -19,7 +19,7 @@ export default function CheckAnswersRoutes({
 
   const ageOfPrisonerRoute = new AgeOfPrisonerRoutes(placeOnReportService, allOffencesSessionService)
   const ageOfPrisonerSubmittedEditRoute = new AgeOfPrisonerSubmittedEditRoutes(
-    placeOnReportService, 
+    placeOnReportService,
     allOffencesSessionService
   )
 

--- a/server/routes/ageOfPrisoner/index.ts
+++ b/server/routes/ageOfPrisoner/index.ts
@@ -12,13 +12,16 @@ export default function CheckAnswersRoutes({
   placeOnReportService,
   allOffencesSessionService,
 }: {
-  placeOnReportService: PlaceOnReportService,
-  allOffencesSessionService: AllOffencesSessionService,
+  placeOnReportService: PlaceOnReportService
+  allOffencesSessionService: AllOffencesSessionService
 }): Router {
   const router = express.Router()
 
   const ageOfPrisonerRoute = new AgeOfPrisonerRoutes(placeOnReportService, allOffencesSessionService)
-  const ageOfPrisonerSubmittedEditRoute = new AgeOfPrisonerSubmittedEditRoutes(placeOnReportService, allOffencesSessionService)
+  const ageOfPrisonerSubmittedEditRoute = new AgeOfPrisonerSubmittedEditRoutes(
+    placeOnReportService, 
+    allOffencesSessionService
+  )
 
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))

--- a/server/routes/ageOfPrisoner/index.ts
+++ b/server/routes/ageOfPrisoner/index.ts
@@ -6,16 +6,19 @@ import AgeOfPrisonerSubmittedEditRoutes from './ageOfPrisonerSubmittedEdit'
 
 import PlaceOnReportService from '../../services/placeOnReportService'
 import adjudicationUrls from '../../utils/urlGenerator'
+import AllOffencesSessionService from '../../services/allOffencesSessionService'
 
 export default function CheckAnswersRoutes({
   placeOnReportService,
+  allOffencesSessionService,
 }: {
-  placeOnReportService: PlaceOnReportService
+  placeOnReportService: PlaceOnReportService,
+  allOffencesSessionService: AllOffencesSessionService,
 }): Router {
   const router = express.Router()
 
-  const ageOfPrisonerRoute = new AgeOfPrisonerRoutes(placeOnReportService)
-  const ageOfPrisonerSubmittedEditRoute = new AgeOfPrisonerSubmittedEditRoutes(placeOnReportService)
+  const ageOfPrisonerRoute = new AgeOfPrisonerRoutes(placeOnReportService, allOffencesSessionService)
+  const ageOfPrisonerSubmittedEditRoute = new AgeOfPrisonerSubmittedEditRoutes(placeOnReportService, allOffencesSessionService)
 
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))

--- a/server/routes/detailsOfOffence/detailsOfOffence_fromSession.test.ts
+++ b/server/routes/detailsOfOffence/detailsOfOffence_fromSession.test.ts
@@ -309,3 +309,33 @@ describe('POST /details-of-offence/100', () => {
       )
   })
 })
+
+describe('POST /details-of-offence/100 - adding first offence', () => {
+  it('should redirect to the incident rule page with resetting-offences flag set - not submitted', () => {
+    const agent = request.agent(app)
+    return agent
+      .get(adjudicationUrls.detailsOfOffence.urls.start(100))
+      .expect(200)
+      .then(() =>
+        agent
+          .post(adjudicationUrls.detailsOfOffence.urls.start(100))
+          .send({ addFirstOffence: true })
+          .expect(302)
+          .expect('Location', adjudicationUrls.ageOfPrisoner.urls.startWithResettingOffences(100))
+      )
+  })
+
+  it('should redirect to the incident rule page with resetting-offences flag set - submitted', () => {
+    const agent = request.agent(app)
+    return agent
+      .get(adjudicationUrls.detailsOfOffence.urls.start(100))
+      .expect(200)
+      .then(() =>
+        agent
+          .post(adjudicationUrls.detailsOfOffence.urls.start(100))
+          .send({ reportedAdjudicationNumber: 1524493, addFirstOffence: true })
+          .expect(302)
+          .expect('Location', adjudicationUrls.ageOfPrisoner.urls.submittedEditWithResettingOffences(100))
+      )
+  })
+})

--- a/server/routes/incidentRole/incidentRolePage.ts
+++ b/server/routes/incidentRole/incidentRolePage.ts
@@ -146,7 +146,7 @@ export default class IncidentRolePage {
       user as User
     )
 
-    const { prisonerNumber } = existingAdjudication.draftAdjudication
+    const { offenceDetails, prisonerNumber } = existingAdjudication.draftAdjudication
 
     debugData('POST', postValues)
     debugData('POST action', postData)
@@ -197,24 +197,11 @@ export default class IncidentRolePage {
       const removeExistingOffences = incidentRoleChanged
       await this.saveToApiUpdate(postValues.draftId, incidentDetailsToSave, removeExistingOffences, user as User)
 
-      let defaultNextPage = NextPageSelectionAfterEdit.TASK_LIST
-      if (this.pageOptions.isPreviouslySubmitted()) {
-        defaultNextPage = NextPageSelectionAfterEdit.OFFENCE_DETAILS
+      const offencesExist = !removeExistingOffences && offenceDetails?.length > 0
+      if (!offencesExist) {
+        return redirectToOffenceSelection(res, postValues.draftId, incidentDetailsToSave.currentIncidentRoleSelection)
       }
-      const nextPageChoice = chooseNextPageAfterEdit(defaultNextPage, incidentRoleChanged)
-      switch (nextPageChoice) {
-        case NextPageSelectionAfterEdit.OFFENCE_SELECTION:
-          return redirectToOffenceSelection(res, postValues.draftId, incidentDetailsToSave.currentIncidentRoleSelection)
-        case NextPageSelectionAfterEdit.OFFENCE_DETAILS:
-          return redirectToOffenceDetails(res, postValues.draftId)
-        default:
-        // Fall through
-      }
-      if (this.pageOptions.isPreviouslySubmitted()) {
-        return redirectToTaskList(res, postValues.draftId)
-      }
-
-      return redirectToOffenceSelection(res, postValues.draftId, incidentDetailsToSave.currentIncidentRoleSelection)
+      return redirectToOffenceDetails(res, postValues.draftId)
     } catch (postError) {
       this.setUpRedirectForEditError(res, postError, postValues.draftId)
       throw postError

--- a/server/routes/incidentRole/incidentRolePage.ts
+++ b/server/routes/incidentRole/incidentRolePage.ts
@@ -583,20 +583,6 @@ const redirectToOffenceDetails = (res: Response, draftId: number) => {
   return res.redirect(adjudicationUrls.detailsOfOffence.urls.start(draftId))
 }
 
-const redirectToTaskList = (res: Response, draftId: number) => {
-  return res.redirect(getTaskListUrl(draftId))
-}
-
-const chooseNextPageAfterEdit = (
-  defaultNextPage: NextPageSelectionAfterEdit,
-  incidentRoleChanged: boolean
-): NextPageSelectionAfterEdit => {
-  if (incidentRoleChanged) {
-    return NextPageSelectionAfterEdit.OFFENCE_SELECTION
-  }
-  return defaultNextPage
-}
-
 // TODO - How best to debug (if at all). We need some unoffical way of logging - do not invoke App Insights
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const debugData = (outputId: string, data: any) => {

--- a/server/routes/incidentRole/incidentRolePage.ts
+++ b/server/routes/incidentRole/incidentRolePage.ts
@@ -82,12 +82,6 @@ enum PageRequestAction {
   DELETE_PRISONER,
 }
 
-enum NextPageSelectionAfterEdit {
-  OFFENCE_SELECTION,
-  OFFENCE_DETAILS,
-  TASK_LIST,
-}
-
 class PageOptions {
   constructor(private readonly pageType: PageRequestType) {}
 

--- a/server/routes/incidentRole/incidentRolePage.ts
+++ b/server/routes/incidentRole/incidentRolePage.ts
@@ -192,7 +192,7 @@ export default class IncidentRolePage {
       await this.saveToApiUpdate(postValues.draftId, incidentDetailsToSave, removeExistingOffences, user as User)
 
       const offencesExist = !removeExistingOffences && offenceDetails?.length > 0
-      if (!offencesExist) {
+      if (!!req.session.forceOffenceSelection || !offencesExist) {
         return redirectToOffenceSelection(res, postValues.draftId, incidentDetailsToSave.currentIncidentRoleSelection)
       }
       return redirectToOffenceDetails(res, postValues.draftId)

--- a/server/routes/incidentRole/incidentRoleSubmittedEdit.test.ts
+++ b/server/routes/incidentRole/incidentRoleSubmittedEdit.test.ts
@@ -41,7 +41,16 @@ beforeEach(() => {
         handoverDeadline: '2022-03-25T09:10:00',
       },
       incidentRole: {},
-      offenceDetails: [],
+      offenceDetails: [
+        {
+          offenceCode: 1001,
+          offenceRule: {
+            paragraphNumber: '1',
+            paragraphDescription: 'Commits any assault',
+          },
+          victimPrisonersNumber: 'G5512G',
+        },
+      ],
       incidentStatement: {
         statement: 'Lorem Ipsum',
         completed: true,
@@ -110,8 +119,6 @@ describe('POST /incident-role/<id>/submitted/edit', () => {
         )}?referrer=${adjudicationUrls.prisonerReport.urls.report(1524455)}`
       )
       .send({
-        incidentDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
-        locationId: 2,
         currentRadioSelected: 'committed',
         originalIncidentRoleSelection: 'committed',
       })
@@ -126,8 +133,6 @@ describe('POST /incident-role/<id>/submitted/edit', () => {
         )}?referrer=${adjudicationUrls.prisonerReport.urls.report(1524455)}`
       )
       .send({
-        incidentDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
-        locationId: 2,
         currentRadioSelected: 'committed',
         originalIncidentRoleSelection: 'committed',
       })
@@ -142,8 +147,6 @@ describe('POST /incident-role/<id>/submitted/edit', () => {
         )}?referrer=${adjudicationUrls.prisonerReport.urls.report(1524455)}`
       )
       .send({
-        incidentDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
-        locationId: 2,
         currentRadioSelected: 'incited',
       })
       .expect(res => {
@@ -160,8 +163,6 @@ describe('POST /incident-role/<id>/submitted/edit', () => {
         )}?referrer=${adjudicationUrls.prisonerReport.urls.report(1524455)}`
       )
       .send({
-        incidentDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
-        locationId: 2,
         currentRadioSelected: 'committed',
       })
       .expect('Content-Type', /html/)
@@ -177,8 +178,6 @@ describe('POST /incident-role/<id>/submitted/edit', () => {
         )}?referrer=${adjudicationUrls.prisonerReport.urls.report(1524455)}`
       )
       .send({
-        incidentDate: { date: '27/10/2021', time: { hour: '12', minute: '30' } },
-        locationId: 2,
         currentRadioSelected: 'committed',
         originalIncidentRoleSelection: 'committed',
       })
@@ -201,8 +200,6 @@ describe('POST /incident-role/<id>/submitted/edit', () => {
         )}?referrer=${adjudicationUrls.prisonerReport.urls.report(1524455)}`
       )
       .send({
-        incidentDate: { date: '27/10/2021', time: { hour: '12', minute: '30' } },
-        locationId: 2,
         currentRadioSelected: 'committed',
         originalIncidentRoleSelection: 'attempted',
       })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -96,7 +96,7 @@ export default function routes(
   if (config.yoiNewPagesFeatureFlag) {
     router.use(
       adjudicationUrls.ageOfPrisoner.root,
-      ageOfPrisonerRoutes({ placeOnReportService, allOffencesSessionService})
+      ageOfPrisonerRoutes({ placeOnReportService, allOffencesSessionService })
     )
   }
   return router

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -94,7 +94,7 @@ export default function routes(
   router.use(adjudicationUrls.deletePerson.root, deletePersonRoutes({ placeOnReportService, userService }))
   router.use('/', homepageRoutes({ userService }))
   if (config.yoiNewPagesFeatureFlag) {
-    router.use(adjudicationUrls.ageOfPrisoner.root, ageOfPrisonerRoutes({ placeOnReportService }))
+    router.use(adjudicationUrls.ageOfPrisoner.root, ageOfPrisonerRoutes({ placeOnReportService, allOffencesSessionService }))
   }
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -94,7 +94,10 @@ export default function routes(
   router.use(adjudicationUrls.deletePerson.root, deletePersonRoutes({ placeOnReportService, userService }))
   router.use('/', homepageRoutes({ userService }))
   if (config.yoiNewPagesFeatureFlag) {
-    router.use(adjudicationUrls.ageOfPrisoner.root, ageOfPrisonerRoutes({ placeOnReportService, allOffencesSessionService }))
+    router.use(
+      adjudicationUrls.ageOfPrisoner.root,
+      ageOfPrisonerRoutes({ placeOnReportService, allOffencesSessionService})
+    )
   }
   return router
 }

--- a/server/services/allOffencesSessionService.ts
+++ b/server/services/allOffencesSessionService.ts
@@ -11,6 +11,10 @@ export default class AllOffencesSessionService {
     req.session.offences?.[draftAdjudicationNumber]?.splice(index - 1, 1)
   }
 
+  deleteAllSessionOffences(req: Request, draftAdjudicationNumber: number) {
+    req.session.offences?.[draftAdjudicationNumber]?.splice(0, req.session.offences?.[draftAdjudicationNumber]?.length)
+  }
+
   setAllSessionOffences(req: Request, offenceData: OffenceData[], draftAdjudicationNumber: number) {
     this.createSessionForAdjudicationIfNotExists(req, draftAdjudicationNumber)
     req.session.offences[draftAdjudicationNumber] = offenceData

--- a/server/utils/urlGenerator.ts
+++ b/server/utils/urlGenerator.ts
@@ -207,7 +207,8 @@ const adjudicationUrls = {
     },
     urls: {
       start: (adjudicationNumber: number) => `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}`,
-      startWithResettingOffences: (adjudicationNumber: number) => `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}?reselectingFirstOffence=true`,
+      startWithResettingOffences: (adjudicationNumber: number) =>
+        `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}?reselectingFirstOffence=true`,
       submittedEdit: (adjudicationNumber: number) =>
         `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}/submitted/edit`,
       submittedEditWithResettingOffences: (adjudicationNumber: number) =>

--- a/server/utils/urlGenerator.ts
+++ b/server/utils/urlGenerator.ts
@@ -207,8 +207,11 @@ const adjudicationUrls = {
     },
     urls: {
       start: (adjudicationNumber: number) => `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}`,
+      startWithResettingOffences: (adjudicationNumber: number) => `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}?reselectingFirstOffence=true`,
       submittedEdit: (adjudicationNumber: number) =>
         `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}/submitted/edit`,
+      submittedEditWithResettingOffences: (adjudicationNumber: number) =>
+        `${adjudicationUrls.ageOfPrisoner.root}/${adjudicationNumber}/submitted/edit?reselectingFirstOffence=true`,
     },
   },
   homepage: {


### PR DESCRIPTION
The first 4 commits are those previously approved.

The rest of the commits fix the following issues:

 - Cannot add an offence when all offences deleted
 - Sometimes offences left on the session and re-appear when editing via Change Your Answers
 - Ensure correct journey used (i.e. submitted edit if relevant) when adding a new offence after deleting all offences.