### PR TITLE
NN-4523: Centralise pageType conditionals with helper

### DIFF
--- a/server/routes/damages/detailsOfDamages.ts
+++ b/server/routes/damages/detailsOfDamages.ts
@@ -7,6 +7,7 @@ import { DamageDetails, DraftAdjudication } from '../../data/DraftAdjudicationRe
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import { User } from '../../data/hmppsAuthClient'
 import { ReportedAdjudication } from '../../data/ReportedAdjudicationResult'
+import DamagesEvidenceWitnessHelper from '../../utils/damagesEvidenceWitnessesHelper'
 
 export enum PageRequestType {
   DAMAGES_FROM_API,
@@ -15,8 +16,10 @@ export enum PageRequestType {
   SUBMITTED_EDIT_DAMAGES_FROM_SESSION,
 }
 
-class PageOptions {
-  constructor(private readonly pageType: PageRequestType) {}
+class PageOptions extends DamagesEvidenceWitnessHelper {
+  constructor(private readonly pageType: PageRequestType) {
+    super()
+  }
 
   displayAPIData(): boolean {
     return this.pageType === PageRequestType.DAMAGES_FROM_API
@@ -51,7 +54,7 @@ export default class DetailsOfDamagesPage {
     const { user } = res.locals
     const adjudicationNumber = Number(req.params.adjudicationNumber)
     const damageToDelete = Number(req.query.delete) || null
-    const isSubmittedEdit = this.pageOptions.displayAPIDataSubmitted() || this.pageOptions.displaySessionDataSubmitted()
+    const isSubmittedEdit = this.pageOptions.isSubmittedEdit()
     const exitButtonHref = this.getExitUrl(req, adjudicationNumber, isSubmittedEdit)
 
     const { adjudication, prisoner } = await this.getAdjudicationAndPrisoner(adjudicationNumber, isSubmittedEdit, user)
@@ -66,7 +69,7 @@ export default class DetailsOfDamagesPage {
     const damages = this.getDamages(req, adjudicationNumber, adjudication)
 
     // If we are not displaying session data then fill in the session data
-    if (this.pageOptions.displayAPIData() || this.pageOptions.displayAPIDataSubmitted()) {
+    if (this.pageOptions.isShowingAPIData()) {
       // Set up session to allow for adding and deleting
       this.damagesSessionService.setAllSessionDamages(req, damages, adjudicationNumber)
     }
@@ -97,7 +100,7 @@ export default class DetailsOfDamagesPage {
   submit = async (req: Request, res: Response): Promise<void> => {
     const { user } = res.locals
     const adjudicationNumber = Number(req.params.adjudicationNumber)
-    const isSubmittedEdit = this.pageOptions.displaySessionDataSubmitted() || this.pageOptions.displayAPIDataSubmitted()
+    const isSubmittedEdit = this.pageOptions.isSubmittedEdit()
 
     const draftAdjudicationResult = !isSubmittedEdit
       ? await this.placeOnReportService.getDraftAdjudicationDetails(adjudicationNumber, user)
@@ -106,10 +109,7 @@ export default class DetailsOfDamagesPage {
     const referrer = this.damagesSessionService.getAndDeleteReferrerOnSession(req)
 
     // If displaying data from API, nothing has changed so no save needed - unless it's the first time viewing the page, when we need to record that the page visit
-    if (
-      (this.pageOptions.displayAPIData() && draftAdjudicationResult.draftAdjudication.damagesSaved) ||
-      this.pageOptions.displayAPIDataSubmitted()
-    ) {
+    if (this.pageOptions.isShowingAPIDataAndPageVisited(draftAdjudicationResult?.draftAdjudication.damagesSaved)) {
       this.damagesSessionService.deleteReferrerOnSession(req)
       this.damagesSessionService.deleteAllSessionDamages(req, adjudicationNumber)
       return this.redirectToNextPage(res, adjudicationNumber, isSubmittedEdit, referrer)
@@ -156,7 +156,7 @@ export default class DetailsOfDamagesPage {
     adjudicationNumber: number,
     draftAdjudication: DraftAdjudication | ReportedAdjudication
   ) => {
-    if (this.pageOptions.displaySessionData() || this.pageOptions.displaySessionDataSubmitted()) {
+    if (this.pageOptions.isShowingSessionData()) {
       return this.damagesSessionService.getAllSessionDamages(req, adjudicationNumber)
     }
 

--- a/server/utils/damagesEvidenceWitnessesHelper.ts
+++ b/server/utils/damagesEvidenceWitnessesHelper.ts
@@ -1,0 +1,25 @@
+export default abstract class DamagesEvidenceWitnessHelper {
+  abstract displayAPIData(): boolean
+
+  abstract displaySessionData(): boolean
+
+  abstract displayAPIDataSubmitted(): boolean
+
+  abstract displaySessionDataSubmitted(): boolean
+
+  isSubmittedEdit() {
+    return this.displayAPIDataSubmitted() || this.displaySessionDataSubmitted()
+  }
+
+  isShowingAPIData() {
+    return this.displayAPIData() || this.displayAPIDataSubmitted()
+  }
+
+  isShowingAPIDataAndPageVisited(apiCalled: boolean) {
+    return (this.displayAPIData() && apiCalled) || this.displayAPIDataSubmitted()
+  }
+
+  isShowingSessionData() {
+    return this.displaySessionData() || this.displaySessionDataSubmitted()
+  }
+}


### PR DESCRIPTION
I've created a centralised abstract class inside a helper file, which can then be accessed by damages, evidence and witness controllers so the logic is shared and each of the files is a bit tidier. 