### PR TITLE
NN-4529: Error messaging and session bug fix

### DIFF
--- a/server/routes/offenceCodeDecisions/offenceCodeDecisions.test.ts
+++ b/server/routes/offenceCodeDecisions/offenceCodeDecisions.test.ts
@@ -243,7 +243,7 @@ describe('POST /offence-code-selection/100/assisted/1 validation', () => {
         selectedAnswerId: aPrisonOfficerAnswer.id(),
       })
       .expect(res => {
-        expect(res.text).toContain('Search for a prison officer')
+        expect(res.text).toContain('Enter the person’s first name')
       })
   })
 
@@ -267,7 +267,7 @@ describe('POST /offence-code-selection/100/assisted/1 validation', () => {
         selectedAnswerId: aMemberOfStaffAnswer.id(),
       })
       .expect(res => {
-        expect(res.text).toContain('Search for a member of staff')
+        expect(res.text).toContain('Enter the person’s first name')
       })
   })
 

--- a/server/routes/offenceCodeDecisions/officerDecisionHelper.ts
+++ b/server/routes/offenceCodeDecisions/officerDecisionHelper.ts
@@ -16,14 +16,20 @@ enum ErrorType {
   OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT = 'OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT',
   OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH = 'OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH',
   OFFICER_MISSING_LAST_NAME_INPUT_SEARCH = 'OFFICER_MISSING_LAST_NAME_INPUT_SEARCH',
+  OFFICER_MISSING_ID_SUBMIT = 'OFFICER_MISSING_ID_SUBMIT',
 }
 const error: { [key in ErrorType]: FormError } = {
+  // We have separated out the submit and search validation messages here
   OFFICER_MISSING_FIRST_NAME_INPUT_SUBMIT: {
     href: '#officerSearchFirstNameInput',
-    text: 'Search for a prison officer',
+    text: 'Enter the person’s first name',
   },
   OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT: {
     href: '#officerSearchLastNameInput',
+    text: 'Enter the person’s last name',
+  },
+  OFFICER_MISSING_ID_SUBMIT: {
+    href: '#selectedAnswerId',
     text: 'Search for a prison officer',
   },
   OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH: {
@@ -79,17 +85,22 @@ export default class OfficerDecisionHelper extends DecisionHelper {
     const officerData = form.selectedAnswerData as OfficerData
     const searching = !!req.body.searchUser
     if (searching) {
-      const errors = []
+      const searchingErrors = []
       if (!officerData.officerSearchFirstNameInput) {
-        errors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH)
+        searchingErrors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH)
       }
       if (!officerData.officerSearchLastNameInput) {
-        errors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SEARCH)
+        searchingErrors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SEARCH)
       }
-      return errors
+      return searchingErrors
     }
     if (!officerData.officerId && !searching) {
-      return [error.OFFICER_MISSING_FIRST_NAME_INPUT_SUBMIT, error.OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT]
+      const submittingErrors = []
+      if (!officerData.officerSearchFirstNameInput) submittingErrors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SUBMIT)
+      if (!officerData.officerSearchLastNameInput) submittingErrors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT)
+      if (officerData.officerSearchFirstNameInput && officerData.officerSearchLastNameInput)
+        submittingErrors.push(error.OFFICER_MISSING_ID_SUBMIT)
+      return submittingErrors
     }
     return []
   }

--- a/server/routes/offenceCodeDecisions/officerDecisionHelper.ts
+++ b/server/routes/offenceCodeDecisions/officerDecisionHelper.ts
@@ -20,6 +20,10 @@ enum ErrorType {
 }
 const error: { [key in ErrorType]: FormError } = {
   // We have separated out the submit and search validation messages here
+  OFFICER_MISSING_ID_SUBMIT: {
+    href: '#selectedAnswerId',
+    text: 'Search for a prison officer',
+  },
   OFFICER_MISSING_FIRST_NAME_INPUT_SUBMIT: {
     href: '#officerSearchFirstNameInput',
     text: 'Enter the person’s first name',
@@ -27,10 +31,6 @@ const error: { [key in ErrorType]: FormError } = {
   OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT: {
     href: '#officerSearchLastNameInput',
     text: 'Enter the person’s last name',
-  },
-  OFFICER_MISSING_ID_SUBMIT: {
-    href: '#selectedAnswerId',
-    text: 'Search for a prison officer',
   },
   OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH: {
     href: '#officerSearchFirstNameInput',
@@ -85,24 +85,37 @@ export default class OfficerDecisionHelper extends DecisionHelper {
     const officerData = form.selectedAnswerData as OfficerData
     const searching = !!req.body.searchUser
     if (searching) {
-      const searchingErrors = []
-      if (!officerData.officerSearchFirstNameInput) {
-        searchingErrors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH)
-      }
-      if (!officerData.officerSearchLastNameInput) {
-        searchingErrors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SEARCH)
-      }
-      return searchingErrors
+      return this.validateSearch(officerData)
     }
     if (!officerData.officerId && !searching) {
-      const submittingErrors = []
-      if (!officerData.officerSearchFirstNameInput) submittingErrors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SUBMIT)
-      if (!officerData.officerSearchLastNameInput) submittingErrors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT)
-      if (officerData.officerSearchFirstNameInput && officerData.officerSearchLastNameInput)
-        submittingErrors.push(error.OFFICER_MISSING_ID_SUBMIT)
-      return submittingErrors
+      return this.validateSubmission(officerData)
     }
     return []
+  }
+
+  validateSearch = (officerData: OfficerData) => {
+    const searchingErrors = []
+    if (!officerData.officerSearchFirstNameInput) {
+      searchingErrors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SEARCH)
+    }
+    if (!officerData.officerSearchLastNameInput) {
+      searchingErrors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SEARCH)
+    }
+    return searchingErrors
+  }
+
+  validateSubmission = (officerData: OfficerData) => {
+    const submittingErrors = []
+    if (!officerData.officerSearchFirstNameInput) {
+      submittingErrors.push(error.OFFICER_MISSING_FIRST_NAME_INPUT_SUBMIT)
+    }
+    if (!officerData.officerSearchLastNameInput) {
+      submittingErrors.push(error.OFFICER_MISSING_LAST_NAME_INPUT_SUBMIT)
+    }
+    if (officerData.officerSearchFirstNameInput && officerData.officerSearchLastNameInput) {
+      submittingErrors.push(error.OFFICER_MISSING_ID_SUBMIT)
+    }
+    return submittingErrors
   }
 
   override async viewDataFromForm(form: DecisionForm, user: User): Promise<unknown> {

--- a/server/routes/offenceCodeDecisions/staffDecisionHelper.ts
+++ b/server/routes/offenceCodeDecisions/staffDecisionHelper.ts
@@ -16,16 +16,22 @@ enum ErrorType {
   STAFF_MISSING_LAST_NAME_INPUT_SUBMIT = 'STAFF_MISSING_LAST_NAME_INPUT_SUBMIT',
   STAFF_MISSING_FIRST_NAME_INPUT_SEARCH = 'STAFF_MISSING_FIRST_NAME_INPUT_SEARCH',
   STAFF_MISSING_LAST_NAME_INPUT_SEARCH = 'STAFF_MISSING_LAST_NAME_INPUT_SEARCH',
+  STAFF_MISSING_ID_SUBMIT = 'STAFF_MISSING_ID_SUBMIT',
 }
 
 const error: { [key in ErrorType]: FormError } = {
+  // We have separated out the submit and search validation messages here
+  STAFF_MISSING_ID_SUBMIT: {
+    href: '#selectedAnswerId',
+    text: 'Search for a member of staff',
+  },
   STAFF_MISSING_FIRST_NAME_INPUT_SUBMIT: {
     href: '#staffSearchFirstNameInput',
-    text: 'Search for a member of staff',
+    text: 'Enter the person’s first name',
   },
   STAFF_MISSING_LAST_NAME_INPUT_SUBMIT: {
     href: '#staffSearchLastNameInput',
-    text: 'Search for a member of staff',
+    text: 'Enter the person’s last name',
   },
   STAFF_MISSING_FIRST_NAME_INPUT_SEARCH: {
     href: '#staffSearchFirstNameInput',
@@ -80,17 +86,22 @@ export default class StaffDecisionHelper extends DecisionHelper {
     const staffData = form.selectedAnswerData as StaffData
     const searching = !!req.body.searchUser
     if (searching) {
-      const errors = []
+      const searchingErrors = []
       if (!staffData.staffSearchFirstNameInput) {
-        errors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SEARCH)
+        searchingErrors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SEARCH)
       }
       if (!staffData.staffSearchLastNameInput) {
-        errors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SEARCH)
+        searchingErrors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SEARCH)
       }
-      return errors
+      return searchingErrors
     }
     if (!staffData.staffId && !searching) {
-      return [error.STAFF_MISSING_FIRST_NAME_INPUT_SUBMIT, error.STAFF_MISSING_LAST_NAME_INPUT_SUBMIT]
+      const submittingErrors = []
+      if (!staffData.staffSearchFirstNameInput) submittingErrors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SUBMIT)
+      if (!staffData.staffSearchLastNameInput) submittingErrors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SUBMIT)
+      if (staffData.staffSearchFirstNameInput && staffData.staffSearchLastNameInput)
+        submittingErrors.push(error.STAFF_MISSING_ID_SUBMIT)
+      return submittingErrors
     }
     return []
   }

--- a/server/routes/offenceCodeDecisions/staffDecisionHelper.ts
+++ b/server/routes/offenceCodeDecisions/staffDecisionHelper.ts
@@ -1,6 +1,6 @@
 // All functionality that knows about the prison decision.
 import { Request } from 'express'
-import { DecisionForm, StaffData } from './decisionForm'
+import { DecisionForm, OfficerData, StaffData } from './decisionForm'
 import { User } from '../../data/hmppsAuthClient'
 import DecisionHelper from './decisionHelper'
 import { FormError } from '../../@types/template'
@@ -86,24 +86,37 @@ export default class StaffDecisionHelper extends DecisionHelper {
     const staffData = form.selectedAnswerData as StaffData
     const searching = !!req.body.searchUser
     if (searching) {
-      const searchingErrors = []
-      if (!staffData.staffSearchFirstNameInput) {
-        searchingErrors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SEARCH)
-      }
-      if (!staffData.staffSearchLastNameInput) {
-        searchingErrors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SEARCH)
-      }
-      return searchingErrors
+      return this.validateSearch(staffData)
     }
     if (!staffData.staffId && !searching) {
-      const submittingErrors = []
-      if (!staffData.staffSearchFirstNameInput) submittingErrors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SUBMIT)
-      if (!staffData.staffSearchLastNameInput) submittingErrors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SUBMIT)
-      if (staffData.staffSearchFirstNameInput && staffData.staffSearchLastNameInput)
-        submittingErrors.push(error.STAFF_MISSING_ID_SUBMIT)
-      return submittingErrors
+      return this.validateSubmission(staffData)
     }
     return []
+  }
+
+  validateSearch = (staffData: StaffData) => {
+    const searchingErrors = []
+    if (!staffData.staffSearchFirstNameInput) {
+      searchingErrors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SEARCH)
+    }
+    if (!staffData.staffSearchLastNameInput) {
+      searchingErrors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SEARCH)
+    }
+    return searchingErrors
+  }
+
+  validateSubmission = (staffData: StaffData) => {
+    const submittingErrors = []
+    if (!staffData.staffSearchFirstNameInput) {
+      submittingErrors.push(error.STAFF_MISSING_FIRST_NAME_INPUT_SUBMIT)
+    }
+    if (!staffData.staffSearchLastNameInput) {
+      submittingErrors.push(error.STAFF_MISSING_LAST_NAME_INPUT_SUBMIT)
+    }
+    if (staffData.staffSearchFirstNameInput && staffData.staffSearchLastNameInput) {
+      submittingErrors.push(error.STAFF_MISSING_ID_SUBMIT)
+    }
+    return submittingErrors
   }
 
   override async viewDataFromForm(form: DecisionForm, user: User): Promise<unknown> {

--- a/server/routes/offenceCodeDecisions/staffDecisionHelper.ts
+++ b/server/routes/offenceCodeDecisions/staffDecisionHelper.ts
@@ -1,6 +1,6 @@
 // All functionality that knows about the prison decision.
 import { Request } from 'express'
-import { DecisionForm, OfficerData, StaffData } from './decisionForm'
+import { DecisionForm, StaffData } from './decisionForm'
 import { User } from '../../data/hmppsAuthClient'
 import DecisionHelper from './decisionHelper'
 import { FormError } from '../../@types/template'

--- a/server/routes/witnesses/addWitness.ts
+++ b/server/routes/witnesses/addWitness.ts
@@ -31,7 +31,7 @@ enum ErrorType {
 const error: { [key in ErrorType]: FormError } = {
   MISSING_DECISION: {
     href: '#selectedAnswerId',
-    text: 'Select an option',
+    text: 'Select the type of witness',
   },
 }
 
@@ -132,6 +132,7 @@ export default class AddWitnessRoutes {
       this.witnessesSessionService.getSubmittedEditFlagFromSession(req),
       adjudicationNumber
     )
+    this.witnessesSessionService.deleteSubmittedEditFlagOnSession(req)
     return res.redirect(redirectUrl)
   }
 

--- a/server/routes/witnesses/detailsOfWitnesses.ts
+++ b/server/routes/witnesses/detailsOfWitnesses.ts
@@ -76,6 +76,9 @@ export default class DetailsOfWitnessesPage {
       this.witnessesSessionService.deleteSessionWitness(req, witnessToDelete, adjudicationNumber)
     }
 
+    // If the user cancelled out of adding a new witness, we need to make sure the session is cleared
+    this.witnessesSessionService.deleteSubmittedEditFlagOnSession(req)
+
     if (!witnesses || witnesses.length < 1) {
       return res.render(`pages/detailsOfWitnesses`, {
         prisoner,
@@ -106,7 +109,6 @@ export default class DetailsOfWitnessesPage {
 
     // If displaying data on draft, nothing has changed so no save needed  - unless it's the first time viewing the page, when we need to record that the page visit
     if (this.pageOptions.isShowingAPIDataAndPageVisited(draftAdjudicationResult?.draftAdjudication.witnessesSaved)) {
-      this.witnessesSessionService.deleteSubmittedEditFlagOnSession(req)
       this.witnessesSessionService.deleteAllSessionWitnesses(req, adjudicationNumber)
       return this.redirectToNextPage(res, adjudicationNumber, isSubmittedEdit, referrer)
     }


### PR DESCRIPTION
- Changes error messaging for different scenarios on witnesses page
- shared code with offences (adding a victim) and error messages tested here too
- fixes bug whereby the submitted status on the session wasn't deleted at the correct point so was still set to true when viewing a draft