### PR TITLE
Nn 4646 maintenance page

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -1,11 +1,11 @@
 import express from 'express'
-
 import path from 'path'
 import createError from 'http-errors'
 import config from './config'
 import GotenbergClient from './data/gotenbergClient'
 
 import indexRoutes from './routes'
+import maintenanceRoutes from './routes/maintenance-index'
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
 import standardRouter from './routes/standardRouter'
@@ -20,6 +20,8 @@ import authorisationMiddleware from './middleware/authorisationMiddleware'
 import logger from '../logger'
 import { Services } from './services'
 import { pdfRenderer } from './utils/pdfRenderer'
+import 'dotenv/config'
+import maintenancePageRouter from './routes/maintenancePageRouter'
 
 export default function createApp(services: Services): express.Application {
   // We do not want the server to exit, partly because any log information will be lost.
@@ -46,7 +48,18 @@ export default function createApp(services: Services): express.Application {
   app.use(pdfRenderer(new GotenbergClient(config.apis.gotenberg.apiUrl)))
   app.use(authorisationMiddleware())
 
-  app.use('/', indexRoutes(standardRouter(services.userService), services))
+  if (process.env.DISPLAY_MAINTENANCE_PAGE === 'true') {
+    app.use('/', maintenanceRoutes(maintenancePageRouter(services.userService)))
+    app.all('*', function (req, res) {
+      res.redirect('/')
+    })
+  } else {
+    app.use('/', indexRoutes(standardRouter(services.userService), services))
+
+    app.all('/planned-maintenance', function (req, res) {
+      res.redirect('/')
+    })
+  }
   app.get('/back-to-start', async (req, res) => {
     const { journeyStartUrl = '/' } = req.session
     delete req.session.journeyStartUrl

--- a/server/config.ts
+++ b/server/config.ts
@@ -117,5 +117,5 @@ export default {
   digitalPrisonServiceUrl: get('DIGITAL_PRISON_SERVICE_URL', 'http://localhost:3002', requiredInProduction),
   supportUrl: get('SUPPORT_URL', 'http://localhost:3003', requiredInProduction),
   yoiNewPagesFeatureFlag: get('YOI_NEW_PAGES_FEATURE_FLAG', true, requiredInProduction),
-  hearingsFeatureFlag: get('HEARINGS_FEATURE_FLAG', false, requiredInProduction),
+  hearingsFeatureFlag: get('HEARINGS_FEATURE_FLAG', true, requiredInProduction),
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -117,5 +117,5 @@ export default {
   digitalPrisonServiceUrl: get('DIGITAL_PRISON_SERVICE_URL', 'http://localhost:3002', requiredInProduction),
   supportUrl: get('SUPPORT_URL', 'http://localhost:3003', requiredInProduction),
   yoiNewPagesFeatureFlag: get('YOI_NEW_PAGES_FEATURE_FLAG', true, requiredInProduction),
-  hearingsFeatureFlag: get('HEARINGS_FEATURE_FLAG', true, requiredInProduction),
+  hearingsFeatureFlag: get('HEARINGS_FEATURE_FLAG', false, requiredInProduction),
 }

--- a/server/routes/maintenance-index.ts
+++ b/server/routes/maintenance-index.ts
@@ -1,0 +1,7 @@
+import type { Router } from 'express'
+import maintenancePageRoutes from './maintenancePage'
+
+export default function routes(router: Router): Router {
+  router.use('/', maintenancePageRoutes())
+  return router
+}

--- a/server/routes/maintenancePage/index.ts
+++ b/server/routes/maintenancePage/index.ts
@@ -1,0 +1,14 @@
+import express, { RequestHandler, Router } from 'express'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+import MaintenanceRoutes from './maintenancePage'
+import adjudicationUrls from '../../utils/urlGenerator'
+
+export default function maintenancePageRoutes(): Router {
+  const router = express.Router()
+  const maintenancePage = new MaintenanceRoutes()
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  get('/', async (req, res) => res.redirect(adjudicationUrls.maintenancePage.root))
+  get(adjudicationUrls.maintenancePage.root, maintenancePage.view)
+  return router
+}

--- a/server/routes/maintenancePage/maintenancePage.test.ts
+++ b/server/routes/maintenancePage/maintenancePage.test.ts
@@ -1,0 +1,31 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes from '../testutils/appSetup'
+import UserService from '../../services/userService'
+import adjudicationUrls from '../../utils/urlGenerator'
+
+jest.mock('../../services/userService.ts')
+
+const userService = new UserService(null) as jest.Mocked<UserService>
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({ production: false }, { userService })
+  userService.getUserRoles.mockResolvedValue([])
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET /planned-maintenance', () => {
+  it('should get the maintenance page', () => {
+    return request(app)
+      .get(adjudicationUrls.maintenancePage.root)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Adjudications')
+      })
+  })
+})

--- a/server/routes/maintenancePage/maintenancePage.ts
+++ b/server/routes/maintenancePage/maintenancePage.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from 'express'
+
+export default class MaintenanceRoutes {
+  view = async (req: Request, res: Response): Promise<void> => {
+    return res.render('pages/maintenancePage')
+  }
+}

--- a/server/routes/maintenancePageRouter.ts
+++ b/server/routes/maintenancePageRouter.ts
@@ -1,0 +1,31 @@
+import { Router } from 'express'
+import csurf from 'csurf'
+import auth from '../authentication/auth'
+import tokenVerifier from '../data/tokenVerification'
+import populateCurrentUser from '../middleware/populateCurrentUser'
+import type UserService from '../services/userService'
+
+const testMode = process.env.NODE_ENV === 'test'
+
+export default function maintenancePageRouter(userService: UserService): Router {
+  const router = Router({ mergeParams: true })
+
+  router.use(auth.authenticationMiddleware(tokenVerifier))
+  router.use(populateCurrentUser(userService))
+
+  // CSRF protection
+  if (!testMode) {
+    router.use(csurf())
+  }
+
+  router.use((req, res, next) => {
+    if (req.query?.journeyStartUrl) req.session.journeyStartUrl = req.query.journeyStartUrl
+
+    if (typeof req.csrfToken === 'function') {
+      res.locals.csrfToken = req.csrfToken()
+    }
+    next()
+  })
+
+  return router
+}

--- a/server/utils/urlGenerator.ts
+++ b/server/utils/urlGenerator.ts
@@ -343,6 +343,12 @@ const adjudicationUrls = {
       start: '/',
     },
   },
+  maintenancePage: {
+    root: '/planned-maintenance',
+    matchers: {
+      start: '*',
+    },
+  },
 }
 
 export default adjudicationUrls

--- a/server/views/pages/maintenancePage.njk
+++ b/server/views/pages/maintenancePage.njk
@@ -1,0 +1,33 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "../partials/card.njk" import card %}
+
+{% set title = "Adjudications" %}
+{% set feedbackBannerBackground = '#f0f4f5 '%}
+
+{% block pageTitle %}
+  {{ title }}
+{% endblock %}
+
+{% block main %}
+  <div class="govuk-width-container">
+
+    {% set mainClasses = "govuk-main-wrapper--l" %}
+    <div class="govuk-grid-row govuk-!-margin-top-7 govuk-!-margin-bottom-7">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">This service is currently unavailable</h1>
+        <p class="govuk-body">
+          You'll be able to use the Adjudications service on DPS again from [9am on Monday, 23 May 2022]
+        </p>
+        <h2 class="govuk-heading-m">Help</>
+        <p class="govuk-body govuk-!-padding-top-2">
+          <a class ="govuk-link" href="#">Contact the Tax Credits Helpline</a> if you need to make changes to your claim or speak to someone about your tax credits.
+        </p>
+      </div>
+    </div>
+  </div>
+
+{% endblock %}
+
+
+


### PR DESCRIPTION
As an organisation there are times when we will need to put the Adjudications service into a maintenance mode. As such we need a holding page we can enable and direct traffic to while the service is down.

DRAFT content below:

'This service is currently unavailable 

You'll be able to use the Adjudications service on DPS again from [9am on Monday, 23 May 2022]. [insert time/date in this format]

The page should be styled in line with the service but stand alone so we can take down all of the services and still use the page.

Technical implementation

Implemented in the Adjudications UI, rather than DPS, incase folks have bookmarked direct pages

Ideally should be behind a feature switch which is sourced from helm config

When true we should enable a catchall Express route which directs users to the maintenance page