### PR TITLE
NN-4630- updated landing page

### DIFF
--- a/server/routes/homepage/homepage.ts
+++ b/server/routes/homepage/homepage.ts
@@ -82,6 +82,22 @@ const createTasks = (): TaskType[] => {
       roles: ['ADJUDICATIONS_REVIEWER'],
       enabled: true,
     },
+    {
+      id: 'print-completed-dis-forms',
+      heading: 'Print Completed DIS 1/ 2 Forms',
+      description: '',
+      href: adjudicationUrls.printCompletedDisForms.root,
+      roles: [],
+      enabled: true,
+    },
+    {
+      id: 'confirm-dis-has-been-issued',
+      heading: 'Confirm DIS 1/ 2 has been issued to the prisoner',
+      description: '',
+      href: adjudicationUrls.confirmDisHasBeenIssued.root,
+      roles: [],
+      enabled: true,
+    },
   ]
 }
 

--- a/server/utils/urlGenerator.ts
+++ b/server/utils/urlGenerator.ts
@@ -361,6 +361,18 @@ const adjudicationUrls = {
       start: '*',
     },
   },
+  printCompletedDisForms: {
+    root: '/print-completed-dis-forms',
+    matchers: {
+      start: '/',
+    },
+  },
+  confirmDisHasBeenIssued: {
+    root: '/confirm-dis-has-been-issued',
+    matchers: {
+      start: '/',
+    },
+  },
 }
 
 export default adjudicationUrls


### PR DESCRIPTION
This PR my overlap work being done in NN-4631.

Display two additional tiles

The two additional tiles can be accessed by all prison officers

Display ‘Print Completed DIS 1/ 2 Forms’ tile

Selecting this  link takes the user  to the  [NN-4633: Adjudication: Print completed DIS 1/ 2 forms- new pageREADY FOR DEV](https://dsdmoj.atlassian.net/browse/NN-4633)

Display ‘Confirm DIS 1/ 2 has been issued to the prisoner’ 

Selecting this  link takes the user  to the  [NN-4631: Adjudication: Confirm DIS 1/ 2 has been issued to the prisoner - new pageIN PROGRESS/DEVELOPMENT](https://dsdmoj.atlassian.net/browse/NN-4631)

