### PR TITLE
NN-4892: Fix enums, add int tests

### DIFF
--- a/server/data/HearingAndOutcomeResult.ts
+++ b/server/data/HearingAndOutcomeResult.ts
@@ -35,7 +35,7 @@ export enum HearingOutcomeAdjournReason {
   RO_ATTEND = 'RO_ATTEND',
   HELP = 'HELP',
   UNFIT = 'UNFIT',
-  WITNESS = 'UNFIT',
+  WITNESS = 'WITNESS',
   WITNESS_SUPPORT = 'WITNESS_SUPPORT',
   MCKENZIE = 'MCKENZIE',
   EVIDENCE = 'EVIDENCE',
@@ -70,9 +70,11 @@ export type HearingOutcomeDetails = {
 
 export type Outcome = {
   id: number
-  code: OutcomeCode
+  code: OutcomeCode | HearingOutcomeFinding
   details: string
   reason?: string
+  amount?: number
+  caution?: boolean
 }
 
 export type ReferralOutcome = {

--- a/server/routes/hearingOutcome/adjourn/hearingAdjournPage.ts
+++ b/server/routes/hearingOutcome/adjourn/hearingAdjournPage.ts
@@ -34,7 +34,7 @@ class PageOptions {
   }
 }
 
-export default class HearingReasonForReferralPage {
+export default class HearingAdournedPage {
   pageOptions: PageOptions
 
   constructor(

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -21,6 +21,7 @@ import { alertFlagLabels, AlertFlags } from '../../utils/alertHelper'
 import {
   HearingDetails,
   HearingOutcomeCode,
+  HearingOutcomeFinding,
   HearingOutcomeResult,
   Outcome,
   OutcomeCode,
@@ -258,17 +259,23 @@ export default class TestData {
     code = OutcomeCode.REFER_POLICE,
     details = 'Some details',
     reason = null,
+    amount = null,
+    caution = null,
   }: {
     id?: number
-    code?: OutcomeCode
+    code?: OutcomeCode | HearingOutcomeFinding
     details?: string
     reason?: NotProceedReason
+    amount?: number
+    caution?: boolean
   }): Outcome => {
     return {
       id,
       code,
       details,
       reason,
+      amount,
+      caution,
     }
   }
 

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -794,7 +794,10 @@ export default class ReportedAdjudicationsService {
     if (!history.length || readOnly) return null
     const finalHistoryItem = history[history.length - 1]
     if (finalHistoryItem.outcome) {
-      if (finalHistoryItem.outcome.outcome.code === OutcomeCode.NOT_PROCEED) {
+      if (
+        finalHistoryItem.outcome.outcome.code === OutcomeCode.NOT_PROCEED &&
+        finalHistoryItem.hearing?.outcome.code !== HearingOutcomeCode.COMPLETE
+      ) {
         return {
           text: 'Remove this outcome',
           name: 'removeOutcomeButton',

--- a/server/views/macros/hearingSummary.njk
+++ b/server/views/macros/hearingSummary.njk
@@ -85,9 +85,9 @@
       {% include '../partials/hearingDetailsVariations/hearingTableExpansions/hearingTableAdjourn.njk' %}
     {% endif %}
     {% if hearingDetails.outcome.code === HearingOutcomeCode.COMPLETE %}
-      {% if outcome.code === OutcomeCode.PROVED %}
+      {% if outcome.code === HearingOutcomeFinding.PROVED %}
         {% include '../partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteProved.njk' %}
-      {% elif outcome.code === OutcomeCode.NOT_PROCEED %}
+      {% elif outcome.code === HearingOutcomeFinding.NOT_PROCEED %}
         {% include '../partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteNotProceed.njk' %}
       {% else %}
         {% include '../partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteDismissed.njk' %}

--- a/server/views/pages/adjudicationForReport/hearingTab.njk
+++ b/server/views/pages/adjudicationForReport/hearingTab.njk
@@ -32,7 +32,7 @@
         {% if item.hearing %}
           {% set hearingNumber = hearingNumber + 1 %}
           {{ hearingTable(hearingNumber, item.hearing, item.outcome, readOnly, reportNo, latestHearingId) }}
-          {% if item.outcome %} 
+          {% if item.outcome and item.hearing.outcome.code != HearingOutcomeCode.COMPLETE %}
             {{ outcomeTable(item, readOnly, reportNo) }}
           {% endif %}
         {% else %}

--- a/server/views/pages/hearingOutcome/adjourn.njk
+++ b/server/views/pages/hearingOutcome/adjourn.njk
@@ -67,7 +67,7 @@
             {  value: HearingOutcomeAdjournReason.INVESTIGATION,
                text: "Further investigation needed"      
             },
-            {  value: "OTHER",
+            {  value: HearingOutcomeAdjournReason.OTHER,
                text: "Other reason"      
             }
          ] | toSelect('value', 'text', adjournReason),


### PR DESCRIPTION
- add integration tests for completed versions of hearing details page
- fix witness enum
- fix 'OTHER' on adjourn enum
- add extra check so that 'not proceed' outcome table doesn't show on complete hearing -> not proceed route version