### PR TITLE
NN-4959: Adapt int tests and add function to get last outcome from array

### DIFF
--- a/integration_tests/integration/hearingTab.cy.ts
+++ b/integration_tests/integration/hearingTab.cy.ts
@@ -692,7 +692,7 @@ context('Hearing details page', () => {
         .then($summaryLabels => {
           expect($summaryLabels.get(0).innerText).to.contain('Reason for referral')
           expect($summaryLabels.get(1).innerText).to.contain('Will this charge continue to prosecution?')
-          expect($summaryLabels.get(2).innerText).to.contain('Next step')
+          expect($summaryLabels.get(2).innerText).to.contain('Outcome')
           expect($summaryLabels.get(3).innerText).to.contain('Reason for not proceeding')
         })
       hearingTabPage
@@ -748,7 +748,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
           expect($summaryLabels.get(5).innerText).to.contain('Reason')
           expect($summaryLabels.get(6).innerText).to.contain('Plea')
         })
@@ -826,7 +826,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
           expect($summaryLabels.get(5).innerText).to.contain('Reason')
           expect($summaryLabels.get(6).innerText).to.contain('Plea')
         })
@@ -953,7 +953,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
         })
 
       hearingTabPage
@@ -967,7 +967,7 @@ context('Hearing details page', () => {
           expect($summaryData.get(4).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(5).innerText).to.contain('Change')
           expect($summaryData.get(6).innerText).to.contain('J. Red')
-          expect($summaryData.get(7).innerText).to.contain('Refer this case to the police')
+          expect($summaryData.get(8).innerText).to.contain('Refer this case to the police')
         })
 
       hearingTabPage
@@ -1006,7 +1006,7 @@ context('Hearing details page', () => {
           expect($summaryData.get(4).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(5).innerText).to.contain('Change')
           expect($summaryData.get(6).innerText).to.contain('J. Red')
-          expect($summaryData.get(7).innerText).to.contain('Refer this case to the police')
+          expect($summaryData.get(8).innerText).to.contain('Refer this case to the police')
         })
 
       hearingTabPage
@@ -1076,7 +1076,7 @@ context('Hearing details page', () => {
           expect($summaryData.get(1).innerText).to.contain('Adj 2')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
-          expect($summaryData.get(4).innerText).to.contain('Refer this case to the police')
+          expect($summaryData.get(5).innerText).to.contain('Refer this case to the police')
         })
 
       hearingTabPage
@@ -1085,7 +1085,7 @@ context('Hearing details page', () => {
         .then($summaryLabels => {
           expect($summaryLabels.get(0).innerText).to.contain('Reason for referral')
           expect($summaryLabels.get(1).innerText).to.contain('Will this charge continue to prosecution?')
-          expect($summaryLabels.get(2).innerText).to.contain('Next step')
+          expect($summaryLabels.get(2).innerText).to.contain('Outcome')
           expect($summaryLabels.get(3).innerText).to.contain('Reason for not proceeding')
         })
 
@@ -1116,7 +1116,7 @@ context('Hearing details page', () => {
           expect($summaryData.get(1).innerText).to.contain('Adj 2')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
-          expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
+          expect($summaryData.get(5).innerText).to.contain('Refer this case to the independent adjudicator')
         })
 
       hearingTabPage.outcomeTableTitle().contains('Independent adjudicator referral')
@@ -1148,7 +1148,7 @@ context('Hearing details page', () => {
           expect($summaryData.get(1).innerText).to.contain('Adj 2')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
-          expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
+          expect($summaryData.get(5).innerText).to.contain('Refer this case to the independent adjudicator')
         })
 
       hearingTabPage.outcomeTableTitle().contains('Independent adjudicator referral')
@@ -1157,7 +1157,7 @@ context('Hearing details page', () => {
         .find('dt')
         .then($summaryLabel => {
           expect($summaryLabel.get(0).innerText).to.contain('Reason for referral')
-          expect($summaryLabel.get(1).innerText).to.contain('Next step')
+          expect($summaryLabel.get(1).innerText).to.contain('Outcome')
         })
       hearingTabPage
         .inAdReferralTable()
@@ -1191,7 +1191,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
           expect($summaryLabels.get(5).innerText).to.contain('Plea')
           expect($summaryLabels.get(6).innerText).to.contain('Finding')
           expect($summaryLabels.get(7).innerText).to.contain('Reason')
@@ -1204,10 +1204,10 @@ context('Hearing details page', () => {
           expect($summaryData.get(2).innerText).to.contain('Adj 2')
           expect($summaryData.get(4).innerText).to.contain('Governor')
           expect($summaryData.get(6).innerText).to.contain('J. Red')
-          expect($summaryData.get(7).innerText).to.contain('Hearing complete - add adjudication finding')
-          expect($summaryData.get(8).innerText).to.contain('Unfit')
-          expect($summaryData.get(9).innerText).to.contain("Charge dismissed due to 'not guilty' finding")
-          expect($summaryData.get(10).innerText).to.contain('Some details')
+          expect($summaryData.get(8).innerText).to.contain('Hearing complete - add adjudication finding')
+          expect($summaryData.get(10).innerText).to.contain('Unfit')
+          expect($summaryData.get(11).innerText).to.contain("Charge dismissed due to 'not guilty' finding")
+          expect($summaryData.get(12).innerText).to.contain('Some details')
         })
       hearingTabPage.removeCompleteHearingOutcomeButton().should('exist')
       hearingTabPage.removeCompleteHearingOutcomeButton().contains('Remove outcome')
@@ -1224,7 +1224,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
           expect($summaryLabels.get(5).innerText).to.contain('Plea')
           expect($summaryLabels.get(6).innerText).to.contain('Finding')
           expect($summaryLabels.get(7).innerText).to.contain('Reason')
@@ -1237,10 +1237,10 @@ context('Hearing details page', () => {
           expect($summaryData.get(2).innerText).to.contain('Adj 2')
           expect($summaryData.get(4).innerText).to.contain('Governor')
           expect($summaryData.get(6).innerText).to.contain('J. Red')
-          expect($summaryData.get(7).innerText).to.contain('Hearing complete - add adjudication finding')
-          expect($summaryData.get(8).innerText).to.contain('Unfit')
-          expect($summaryData.get(9).innerText).to.contain('Charge not proceeded with for any other reason')
-          expect($summaryData.get(10).innerText).to.contain('Hearing open outside timeframe\n\nSome details')
+          expect($summaryData.get(8).innerText).to.contain('Hearing complete - add adjudication finding')
+          expect($summaryData.get(10).innerText).to.contain('Unfit')
+          expect($summaryData.get(11).innerText).to.contain('Charge not proceeded with for any other reason')
+          expect($summaryData.get(12).innerText).to.contain('Hearing open outside timeframe\n\nSome details')
         })
       hearingTabPage.notProceedTable().should('not.exist')
       hearingTabPage.removeCompleteHearingOutcomeButton().should('exist')
@@ -1258,7 +1258,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
           expect($summaryLabels.get(5).innerText).to.contain('Plea')
           expect($summaryLabels.get(6).innerText).to.contain('Finding')
         })
@@ -1270,9 +1270,9 @@ context('Hearing details page', () => {
           expect($summaryData.get(2).innerText).to.contain('Adj 2')
           expect($summaryData.get(4).innerText).to.contain('Governor')
           expect($summaryData.get(6).innerText).to.contain('J. Red')
-          expect($summaryData.get(7).innerText).to.contain('Hearing complete - add adjudication finding')
-          expect($summaryData.get(8).innerText).to.contain('Unfit')
-          expect($summaryData.get(9).innerText).to.contain('Charge proved beyond reasonable doubt')
+          expect($summaryData.get(8).innerText).to.contain('Hearing complete - add adjudication finding')
+          expect($summaryData.get(10).innerText).to.contain('Unfit')
+          expect($summaryData.get(11).innerText).to.contain('Charge proved beyond reasonable doubt')
         })
       hearingTabPage.removeCompleteHearingOutcomeButton().should('exist')
       hearingTabPage.removeHearingButton().should('not.exist')
@@ -1474,7 +1474,7 @@ context('Hearing details page', () => {
           expect($summaryLabels.get(1).innerText).to.contain('Location')
           expect($summaryLabels.get(2).innerText).to.contain('Type of hearing')
           expect($summaryLabels.get(3).innerText).to.contain('Name of adjudicator')
-          expect($summaryLabels.get(4).innerText).to.contain('Next step')
+          expect($summaryLabels.get(4).innerText).to.contain('Outcome')
           expect($summaryLabels.get(5).innerText).to.contain('Reason')
           expect($summaryLabels.get(6).innerText).to.contain('Plea')
         })
@@ -1512,7 +1512,7 @@ context('Hearing details page', () => {
           expect($summaryData.get(1).innerText).to.contain('Adj 2')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
-          expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
+          expect($summaryData.get(5).innerText).to.contain('Refer this case to the independent adjudicator')
         })
 
       hearingTabPage.outcomeTableTitle().contains('Independent adjudicator referral')
@@ -1521,7 +1521,7 @@ context('Hearing details page', () => {
         .find('dt')
         .then($summaryLabel => {
           expect($summaryLabel.get(0).innerText).to.contain('Reason for referral')
-          expect($summaryLabel.get(1).innerText).to.contain('Next step')
+          expect($summaryLabel.get(1).innerText).to.contain('Outcome')
         })
       hearingTabPage
         .inAdReferralTable()

--- a/server/services/reportedAdjudicationsService.test.ts
+++ b/server/services/reportedAdjudicationsService.test.ts
@@ -908,18 +908,6 @@ describe('reportedAdjudicationsService', () => {
     })
   })
   describe('getLastOutcomeItem', () => {
-    it.skip('throw error if there are no outcomes on the adjudication', async () => {
-      getReportedAdjudication.mockResolvedValue({
-        reportedAdjudication: testData.reportedAdjudication({
-          adjudicationNumber: 123,
-          prisonerNumber: 'A1234AA',
-          dateTimeOfIncident: '2021-10-28T15:40:25.884',
-        }),
-      })
-      return expect(() => {
-        service.getLastOutcomeItem(123, user)
-      }).toThrow(new Error('Missing outcomes data'))
-    })
     it('returns the only item if there is only one outcome on the adjudication', async () => {
       getReportedAdjudication.mockResolvedValue({
         reportedAdjudication: testData.reportedAdjudication({
@@ -1017,6 +1005,16 @@ describe('reportedAdjudicationsService', () => {
           }),
         },
       })
+    })
+    it.skip('throw error if there are no outcomes on the adjudication', async () => {
+      getReportedAdjudication.mockResolvedValue({
+        reportedAdjudication: testData.reportedAdjudication({
+          adjudicationNumber: 123,
+          prisonerNumber: 'A1234AA',
+          dateTimeOfIncident: '2021-10-28T15:40:25.884',
+        }),
+      })
+      expect(() => service.getLastOutcomeItem(123, user)).toThrow()
     })
   })
 })

--- a/server/services/reportedAdjudicationsService.test.ts
+++ b/server/services/reportedAdjudicationsService.test.ts
@@ -908,7 +908,7 @@ describe('reportedAdjudicationsService', () => {
     })
   })
   describe('getLastOutcomeItem', () => {
-    it('returns null if there are no outcomes on the adjudication', async () => {
+    it.skip('throw error if there are no outcomes on the adjudication', async () => {
       getReportedAdjudication.mockResolvedValue({
         reportedAdjudication: testData.reportedAdjudication({
           adjudicationNumber: 123,
@@ -916,8 +916,9 @@ describe('reportedAdjudicationsService', () => {
           dateTimeOfIncident: '2021-10-28T15:40:25.884',
         }),
       })
-      const result = await service.getLastOutcomeItem(123, user)
-      expect(result).toEqual(null)
+      return expect(() => {
+        service.getLastOutcomeItem(123, user)
+      }).toThrow(new Error('Missing outcomes data'))
     })
     it('returns the only item if there is only one outcome on the adjudication', async () => {
       getReportedAdjudication.mockResolvedValue({

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -868,4 +868,11 @@ export default class ReportedAdjudicationsService {
     }
     return null
   }
+
+  async getLastOutcomeItem(adjudicationNumber: number, user: User) {
+    const adjudication = await this.getReportedAdjudicationDetails(adjudicationNumber, user)
+    const { reportedAdjudication } = adjudication
+    if (!reportedAdjudication.outcomes) return null
+    return reportedAdjudication.outcomes[reportedAdjudication.outcomes.length - 1]
+  }
 }

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -872,7 +872,7 @@ export default class ReportedAdjudicationsService {
   async getLastOutcomeItem(adjudicationNumber: number, user: User) {
     const adjudication = await this.getReportedAdjudicationDetails(adjudicationNumber, user)
     const { reportedAdjudication } = adjudication
-    if (!reportedAdjudication.outcomes) return null
+    if (!reportedAdjudication.outcomes) throw new Error(`Missing outcomes data`)
     return reportedAdjudication.outcomes[reportedAdjudication.outcomes.length - 1]
   }
 }

--- a/server/views/macros/hearingSummary.njk
+++ b/server/views/macros/hearingSummary.njk
@@ -32,27 +32,7 @@
         attributes: {"data-qa": "change-link" }
       }
     ]
-  } %}
-    {# {% set adjudicatorChangeLink = {
-    items: [
-      {
-        href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
-        text: "Change",
-        visuallyHiddenText: ' name of adjudicator',
-        attributes: {"data-qa": "change-link-hearing-outcome-adjudicator-name" }
-      }
-    ]
-  } %} #}
-    {# {% set nextStepChangeLink = {
-    items: [
-      {
-        href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
-        text: "Change",
-        visuallyHiddenText: ' next step',
-        attributes: {"data-qa": "change-link-hearing-outcome-next-step" }
-      }
-    ]
-  } %} #}
+    }  %}
   {% endif %}
 
   {% set rows = [

--- a/server/views/macros/outcomeSummaries/outcomeInAdReferralSummary.njk
+++ b/server/views/macros/outcomeSummaries/outcomeInAdReferralSummary.njk
@@ -21,7 +21,7 @@
     {% set notProceeding = referralDetails.code == ReferralOutcomeCode.NOT_PROCEED %} 
       {% set rows = (rows.push({
         key: {
-          text: 'Next step'
+          text: 'Outcome'
         },
         value: {
           text: nextStep

--- a/server/views/macros/outcomeSummaries/outcomePoliceReferralSummary.njk
+++ b/server/views/macros/outcomeSummaries/outcomePoliceReferralSummary.njk
@@ -35,7 +35,7 @@
     {% if not prosecute %}
       {% set rows = (rows.push({
         key: {
-          text: 'Next step'
+          text: 'Outcome'
         },
         value: {
           text: nextStep

--- a/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableAdjourn.njk
+++ b/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableAdjourn.njk
@@ -8,7 +8,7 @@
     }
   }, {
     key: {
-      text: 'Next step'
+      text: 'Outcome'
     },
     value: {
       text: 'Adjourn the hearing for another reason'

--- a/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteDismissed.njk
+++ b/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteDismissed.njk
@@ -1,3 +1,24 @@
+{% set adjudicatorChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' name of adjudicator',
+      attributes: {"data-qa": "change-link-hearing-outcome-adjudicator-name" }
+    }
+  ]
+} %}
+{% set outcomeChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' outcome',
+      attributes: {"data-qa": "change-link-hearing-outcome-outcome" }
+    }
+  ]
+} %}
+
 {% set newRows = [
   {
     key: {
@@ -5,14 +26,16 @@
     },
     value: {
       text: hearingDetails.outcome.adjudicator | initialiseName
-    }
+    },
+    actions: adjudicatorChangeLink
   }, {
     key: {
-      text: 'Next step'
+      text: 'Outcome'
     },
     value: {
       text: 'Hearing complete - add adjudication finding'
-    }
+    },
+    actions: outcomeChangeLink
   }, 
   {
     key: { text: 'Plea' },

--- a/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteNotProceed.njk
+++ b/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteNotProceed.njk
@@ -1,3 +1,24 @@
+{% set adjudicatorChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' name of adjudicator',
+      attributes: {"data-qa": "change-link-hearing-outcome-adjudicator-name" }
+    }
+  ]
+} %}
+{% set outcomeChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' outcome',
+      attributes: {"data-qa": "change-link-hearing-outcome-outcome" }
+    }
+  ]
+} %}
+
 {% set newRows = [
   {
     key: {
@@ -5,14 +26,16 @@
     },
     value: {
       text: hearingDetails.outcome.adjudicator | initialiseName
-    }
+    },
+    actions: adjudicatorChangeLink
   }, {
     key: {
-      text: 'Next step'
+      text: 'Outcome'
     },
     value: {
       text: 'Hearing complete - add adjudication finding'
-    }
+    },
+    actions: outcomeChangeLink
   }, 
   {
     key: { text: 'Plea' },

--- a/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteProved.njk
+++ b/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableCompleteProved.njk
@@ -1,3 +1,24 @@
+{% set adjudicatorChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' name of adjudicator',
+      attributes: {"data-qa": "change-link-hearing-outcome-adjudicator-name" }
+    }
+  ]
+} %}
+{% set outcomeChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' outcome',
+      attributes: {"data-qa": "change-link-hearing-outcome-outcome" }
+    }
+  ]
+} %}
+
 {% set newRows = [
   {
     key: {
@@ -5,14 +26,16 @@
     },
     value: {
       text: hearingDetails.outcome.adjudicator | initialiseName
-    }
+    },
+    actions: adjudicatorChangeLink
   }, {
     key: {
-      text: 'Next step'
+      text: 'Outcome'
     },
     value: {
       text: 'Hearing complete - add adjudication finding'
-    }
+    },
+    actions: outcomeChangeLink
   }, 
   {
     key: { text: 'Plea' },

--- a/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableReferInAdExpansion.njk
+++ b/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableReferInAdExpansion.njk
@@ -1,3 +1,24 @@
+{% set adjudicatorChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' name of adjudicator',
+      attributes: {"data-qa": "change-link-hearing-outcome-adjudicator-name" }
+    }
+  ]
+} %}
+{% set outcomeChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' outcome',
+      attributes: {"data-qa": "change-link-hearing-outcome-outcome" }
+    }
+  ]
+} %}
+
 {% set newRows = [
   {
     key: {
@@ -5,14 +26,16 @@
     },
     value: {
       text: hearingDetails.outcome.adjudicator | initialiseName
-    }
+    },
+        actions: adjudicatorChangeLink
   }, {
     key: {
-      text: 'Next step'
+      text: 'Outcome'
     },
     value: {
       text: 'Refer this case to the independent adjudicator'
-    }
+    },
+        actions: outcomeChangeLink
   }
 ]
  %}

--- a/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableReferPoliceExpansion.njk
+++ b/server/views/partials/hearingDetailsVariations/hearingTableExpansions/hearingTableReferPoliceExpansion.njk
@@ -1,3 +1,24 @@
+{% set adjudicatorChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' name of adjudicator',
+      attributes: {"data-qa": "change-link-hearing-outcome-adjudicator-name" }
+    }
+  ]
+} %}
+{% set outcomeChangeLink = {
+  items: [
+    {
+      href: adjudicationUrls.enterHearingOutcome.urls.edit(adjudicationNumber, hearingId), 
+      text: "Change",
+      visuallyHiddenText: ' outcome',
+      attributes: {"data-qa": "change-link-hearing-outcome-outcome" }
+    }
+  ]
+} %}
+
 {% set newRows = [
   {
     key: {
@@ -5,14 +26,16 @@
     },
     value: {
       text: hearingDetails.outcome.adjudicator | initialiseName
-    }
+    },
+    actions: adjudicatorChangeLink
   }, {
     key: {
-      text: 'Next step'
+      text: 'Outcome'
     },
     value: {
       text: 'Refer this case to the police'
-    }
+    },
+    actions: outcomeChangeLink
   }
 ]
  %}


### PR DESCRIPTION
- changes 'next step' label to 'outcomes' label on summary
- adds change links for name of adjudicator and outcome data
- **does not add** any logic as to when these change links are visible - this will be done in a later PR
- adds new function to get adjudication and retrieve the final outcome item