### PR TITLE
NN-4777: Validation bits

### DIFF
--- a/integration_tests/integration/awardPunishmentsEdit.cy.ts
+++ b/integration_tests/integration/awardPunishmentsEdit.cy.ts
@@ -165,7 +165,7 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       punishmentSchedulePage.submitButton().click()
     })
 
-    it('create and edit punishments - PROSPECTIVE DAYS - force update to file', () => {
+    it('create and edit punishments - PROSPECTIVE DAYS', () => {
       cy.visit(adjudicationUrls.awardPunishments.urls.start(100))
       const awardPunishmentsPage = Page.verifyOnPage(AwardPunishmentsPage)
 

--- a/integration_tests/integration/awardPunishmentsEdit.cy.ts
+++ b/integration_tests/integration/awardPunishmentsEdit.cy.ts
@@ -165,7 +165,7 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       punishmentSchedulePage.submitButton().click()
     })
 
-    it.only('create and edit punishments - PROSPECTIVE DAYS', () => {
+    it('create and edit punishments - PROSPECTIVE DAYS - force update to file', () => {
       cy.visit(adjudicationUrls.awardPunishments.urls.start(100))
       const awardPunishmentsPage = Page.verifyOnPage(AwardPunishmentsPage)
 

--- a/integration_tests/integration/awardPunishmentsEdit.cy.ts
+++ b/integration_tests/integration/awardPunishmentsEdit.cy.ts
@@ -22,8 +22,8 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       id: 100,
       response: {
         reportedAdjudication: {
-          punishments: [],
           ...testData.reportedAdjudication({
+            punishments: [],
             adjudicationNumber: 3,
             prisonerNumber: 'G6415GD',
             locationId: 25538,
@@ -165,7 +165,7 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       punishmentSchedulePage.submitButton().click()
     })
 
-    it('create and edit punishments - PROSPECTIVE DAYS', () => {
+    it.only('create and edit punishments - PROSPECTIVE DAYS', () => {
       cy.visit(adjudicationUrls.awardPunishments.urls.start(100))
       const awardPunishmentsPage = Page.verifyOnPage(AwardPunishmentsPage)
 
@@ -177,8 +177,9 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       punishmentPage.submitButton().click()
 
       const punishmentSchedulePage = Page.verifyOnPage(PunishmentSchedulePage)
-      punishmentSchedulePage.suspended().should('not.exist')
+      punishmentSchedulePage.suspended().should('exist')
       punishmentSchedulePage.days().type('10')
+      punishmentSchedulePage.suspended().find('input[value="no"]').click()
 
       punishmentSchedulePage.submitButton().click()
 

--- a/integration_tests/integration/punishment.cy.ts
+++ b/integration_tests/integration/punishment.cy.ts
@@ -76,7 +76,7 @@ context('Add a new punishment', () => {
           expect($error.get(0).innerText).to.contain('Enter a privilege to be withdrawn')
         })
     })
-    it('should error when no  stoppage percentate selected', () => {
+    it('should error when no  stoppage percentage selected', () => {
       cy.visit(adjudicationUrls.punishment.urls.start(100))
       const punishmentPage = Page.verifyOnPage(PunishmentPage)
       punishmentPage.punishment().find('input[value="EARNINGS"]').check()
@@ -138,7 +138,7 @@ context('Add a new punishment', () => {
 
       punishmentPage.punishment().find('input[value="PRIVILEGE"]').check()
       punishmentPage.privilege().find('input[value="OTHER"]').check()
-      punishmentPage.otherPrivilege().type('ninentdo switch')
+      punishmentPage.otherPrivilege().type('nintendo switch')
 
       punishmentPage.submitButton().click()
 

--- a/integration_tests/integration/punishmentSchedule.cy.ts
+++ b/integration_tests/integration/punishmentSchedule.cy.ts
@@ -26,6 +26,22 @@ context('Punishment schedule', () => {
       punishmentSchedulePage.days().should('exist')
       punishmentSchedulePage.suspended().should('exist')
     })
+    it('should not ask for start and end dates if the punishment type is additional days ', () => {
+      cy.visit(`${adjudicationUrls.punishmentSchedule.urls.start(100)}?punishmentType=ADDITIONAL_DAYS`)
+      const punishmentSchedulePage = Page.verifyOnPage(PunishmentSchedulePage)
+      punishmentSchedulePage.days().type('10')
+      punishmentSchedulePage.suspended().find('input[value="no"]').check()
+      punishmentSchedulePage.startDate().should('not.exist')
+      punishmentSchedulePage.endDate().should('not.exist')
+    })
+    it('should not ask for start and end dates if the punishment type is prospective days ', () => {
+      cy.visit(`${adjudicationUrls.punishmentSchedule.urls.start(100)}?punishmentType=PROSPECTIVE_DAYS`)
+      const punishmentSchedulePage = Page.verifyOnPage(PunishmentSchedulePage)
+      punishmentSchedulePage.days().type('10')
+      punishmentSchedulePage.suspended().find('input[value="no"]').check()
+      punishmentSchedulePage.startDate().should('not.exist')
+      punishmentSchedulePage.endDate().should('not.exist')
+    })
     it('cancel link goes back to punishments page', () => {
       cy.visit(adjudicationUrls.punishmentSchedule.urls.start(100))
       const punishmentSchedulePage = Page.verifyOnPage(PunishmentSchedulePage)
@@ -59,7 +75,7 @@ context('Punishment schedule', () => {
         .errorSummary()
         .find('li')
         .then($error => {
-          expect($error.get(0).innerText).to.contain('Select yes, if this punishment is to be suspended')
+          expect($error.get(0).innerText).to.contain('Select yes if this punishment is to be suspended')
         })
     })
     it('should error when suspended and no date selected', () => {

--- a/server/routes/punishment/punishmentValidation.test.ts
+++ b/server/routes/punishment/punishmentValidation.test.ts
@@ -75,4 +75,26 @@ describe('validateForm', () => {
       text: 'Enter the loss of privileges',
     })
   })
+  it('shows error when stoppage percentage is more than 100', () => {
+    expect(
+      validateForm({
+        punishmentType: PunishmentType.EARNINGS,
+        stoppagePercentage: 101,
+      })
+    ).toEqual({
+      href: '#stoppagePercentage',
+      text: 'Enter a number between 0 and 100',
+    })
+  })
+  it('shows error when stoppage percentage is less than 1', () => {
+    expect(
+      validateForm({
+        punishmentType: PunishmentType.EARNINGS,
+        stoppagePercentage: -3,
+      })
+    ).toEqual({
+      href: '#stoppagePercentage',
+      text: 'Enter a number between 0 and 100',
+    })
+  })
 })

--- a/server/routes/punishment/punishmentValidation.ts
+++ b/server/routes/punishment/punishmentValidation.ts
@@ -25,6 +25,10 @@ const errors: { [key: string]: FormError } = {
     href: '#stoppagePercentage',
     text: 'Enter the loss of privileges',
   },
+  STOPPAGE_PERCENTAGE: {
+    href: '#stoppagePercentage',
+    text: 'Enter a number between 0 and 100',
+  },
 }
 
 export default function validateForm({
@@ -41,5 +45,8 @@ export default function validateForm({
     return errors.MISSING_OTHER_PRIVILEGE
 
   if (punishmentType === PunishmentType.EARNINGS && !stoppagePercentage) return errors.MISSING_STOPPAGE_PERCENTAGE
+
+  if (punishmentType === PunishmentType.EARNINGS && (stoppagePercentage < 1 || stoppagePercentage > 100))
+    return errors.STOPPAGE_PERCENTAGE
   return null
 }

--- a/server/routes/punishmentSchedule/punishmentScheduleValidation.test.ts
+++ b/server/routes/punishmentSchedule/punishmentScheduleValidation.test.ts
@@ -29,6 +29,7 @@ describe('validateForm', () => {
       validateForm({
         punishmentType: PunishmentType.PROSPECTIVE_DAYS,
         days: 10,
+        suspended: 'no',
       })
     ).toBeNull()
   })
@@ -38,11 +39,33 @@ describe('validateForm', () => {
       validateForm({
         punishmentType: PunishmentType.ADDITIONAL_DAYS,
         days: 10,
+        suspended: 'no',
+      })
+    ).toBeNull()
+  })
+  it('Valid submit when prospective days - suspended', () => {
+    expect(
+      validateForm({
+        punishmentType: PunishmentType.PROSPECTIVE_DAYS,
+        days: 10,
+        suspended: 'yes',
+        suspendedUntil: '10/5/2023',
       })
     ).toBeNull()
   })
 
-  it('shows error when no  days select', () => {
+  it('Valid submit when additional days - suspended', () => {
+    expect(
+      validateForm({
+        punishmentType: PunishmentType.ADDITIONAL_DAYS,
+        days: 10,
+        suspended: 'yes',
+        suspendedUntil: '10/5/2023',
+      })
+    ).toBeNull()
+  })
+
+  it('shows error when no days select', () => {
     expect(
       validateForm({
         punishmentType: PunishmentType.CONFINEMENT,
@@ -54,6 +77,18 @@ describe('validateForm', () => {
       text: 'Enter how many days the punishment will last',
     })
   })
+  it('shows error when too few days are entered', () => {
+    expect(
+      validateForm({
+        punishmentType: PunishmentType.CONFINEMENT,
+        days: 0,
+        suspended: null,
+      })
+    ).toEqual({
+      href: '#days',
+      text: 'Enter 1 or more days',
+    })
+  })
   it('shows error when suspended decision not select', () => {
     expect(
       validateForm({
@@ -63,7 +98,7 @@ describe('validateForm', () => {
       })
     ).toEqual({
       href: '#suspended',
-      text: 'Select yes, if this punishment is to be suspended',
+      text: 'Select yes if this punishment is to be suspended',
     })
   })
   it('shows error when suspended date not set', () => {
@@ -101,6 +136,20 @@ describe('validateForm', () => {
     ).toEqual({
       href: '#endDate',
       text: 'Enter the last day of this punishment',
+    })
+  })
+  it('shows error when end date is before start date', () => {
+    expect(
+      validateForm({
+        punishmentType: PunishmentType.CONFINEMENT,
+        days: 10,
+        suspended: 'no',
+        startDate: '13/4/2023',
+        endDate: '3/4/2023',
+      })
+    ).toEqual({
+      href: '#endDate',
+      text: 'Enter an end date that is after the start date',
     })
   })
 })

--- a/server/views/macros/awardPunishmentsTable.njk
+++ b/server/views/macros/awardPunishmentsTable.njk
@@ -19,11 +19,11 @@
             classes: "columnWidth30"
           },
           {
-            text: data.startDate | formatTimestampTo('DD MMM YYYY') if data.startDate else '-',
+            text: data.startDate | formatTimestampTo('D MMM YYYY') if data.startDate else '-',
             classes: "columnWidth15"
           },
           {
-            text: data.endDate | formatTimestampTo('DD MMM YYYY') if data.endDate else '-',
+            text: data.endDate | formatTimestampTo('D MMM YYYY') if data.endDate else '-',
             classes: "columnWidth15"
           },
           {
@@ -31,7 +31,7 @@
             classes: "columnWidth12"
           },
           {
-            text: data.suspendedUntil | formatTimestampTo('DD MMM YYYY') if data.suspendedUntil  else '-',
+            text: data.suspendedUntil | formatTimestampTo('D MMM YYYY') if data.suspendedUntil  else '-',
             classes: "columnWidth12"
           },
           {

--- a/server/views/pages/adjudicationForReport/punishmentsTab.njk
+++ b/server/views/pages/adjudicationForReport/punishmentsTab.njk
@@ -38,7 +38,20 @@
       }) }}
       </div>
       {% endif %}
+      {% else %}
+      <div>
+        {{ govukButton({
+        text: 'Award punishments',
+        element: "a",
+        href: adjudicationUrls.awardPunishments.urls.start(reportNo),
+        classes: "govuk-button--submit govuk-!-margin-right-3",
+        attributes: { "data-qa": "award-punishments" }
+      }) }}
+      </div>
     {% endif %}
+    {% else %}
+    <p class="govuk-body govuk-!-margin-top-5">There are no punishments added.</p>
+    <p class="govuk-body govuk-!-margin-top-3">You can only add punishments if the charge is proved.</p>
   {% endif %}
 
 {% endblock %}

--- a/server/views/pages/punishmentSchedule.njk
+++ b/server/views/pages/punishmentSchedule.njk
@@ -8,67 +8,68 @@
 
 {% set title = "Punishment schedule" %}
 {% block pageTitle %}
-    {{ title }}
+  {{ title }}
 {% endblock %}
 {% block beforeContent %}
-    {{ breadcrumb() }}
+  {{ breadcrumb() }}
 {% endblock %}
 
 {% set suspendedUntilHtml %}
 <h2 class="govuk-heading-s">When will it be suspended until?</h2>
 {{
-            datePicker({
-            id: 'suspendedUntil',
-            label: 'Suspended until',
-            name: 'suspendedUntil',
-            date: suspendedUntil,
-            attributes: {'data-disable-future-date':'false', 'data-qa': "suspended-until-date-picker" },
-            classes: 'govuk-input--width-10'
-        })
-        }}
+    datePicker({
+    id: 'suspendedUntil',
+    label: 'Suspended until',
+    name: 'suspendedUntil',
+    date: suspendedUntil,
+    attributes: {'data-disable-future-date':'false', 'data-qa': "suspended-until-date-picker" },
+    classes: 'govuk-input--width-10'
+    })
+  }}
 {% endset -%}
 
 {% set notSuspendedHtml %}
-<h2 class="govuk-heading-s">When will this punishment start?</h2>
-
-{{
-            datePicker({
-            id: 'startDate',
-            label: 'Start date',
-            name: 'startDate',
-            date: startDate,
-            attributes: {'data-disable-future-date':'false', 'data-qa': "start-date-picker" },
-            classes: 'govuk-input--width-10'
-        })   
-        }}
-<h2 class="govuk-heading-s">What is the last day of this punishment?</h2>
-{{
-            datePicker({
-            id: 'endDate',
-            label: 'Last day',
-            name: 'endDate',
-            date: endDate,
-            attributes: {'data-disable-future-date':'false', 'data-qa': "end-date-picker" },
-            classes: 'govuk-input--width-10'
-        })
-        }}
+{% if displaySuspended %}
+  <h2 class="govuk-heading-s">When will this punishment start?</h2>
+  {{
+      datePicker({
+      id: 'startDate',
+      label: 'Start date',
+      name: 'startDate',
+      date: startDate,
+      attributes: {'data-disable-future-date':'false', 'data-qa': "start-date-picker" },
+      classes: 'govuk-input--width-10'
+      })   
+    }}
+  <h2 class="govuk-heading-s">What is the last day of this punishment?</h2>
+  {{
+    datePicker({
+    id: 'endDate',
+    label: 'Last day',
+    name: 'endDate',
+    date: endDate,
+    attributes: {'data-disable-future-date':'false', 'data-qa': "end-date-picker" },
+    classes: 'govuk-input--width-10'
+    })
+  }}
+{% endif %}
 
 {% endset -%}
 
 {% block content %}
-    {% if errors | length %}
-        {{ govukErrorSummary({
+  {% if errors | length %}
+    {{ govukErrorSummary({
       titleText: "There is a problem",
       errorList: errors,
       attributes: { "data-qa": "error-summary" }
     }) }}
-    {% endif %}
-    <h1 class="govuk-heading-l">{{ title }}</h1>
-    <div>
-        <form method="POST" novalidate="novalidate" class="govuk-!-margin-top-5">
-            <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+  {% endif %}
+  <h1 class="govuk-heading-l">{{ title }}</h1>
+  <div>
+    <form method="POST" novalidate="novalidate" class="govuk-!-margin-top-5">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-            {{ govukInput({
+      {{ govukInput({
              id: "days",
              name: "days",
              value: days,
@@ -79,9 +80,7 @@
              }
              }) }}
 
-            {% if displaySuspended %}
-
-                {{      govukRadios({
+      {{ govukRadios({
              idPrefix: 'suspended',
              id: 'suspended',
              name: 'suspended',
@@ -109,17 +108,16 @@
              ] }) 
              }}
 
-            {% endif %}
-            <div class="govuk-button-group">
-                {{ govukButton({
+      <div class="govuk-button-group">
+        {{ govukButton({
               text: 'Continue',
               type: "submit",
               classes: "govuk-button--submit govuk-!-margin-right-3",
               attributes: { "data-qa": "punishment-schedule-submit" }
               }) }}
-                <a class="govuk-link" href=' {{ cancelHref }} ' data-qa='punishment-schedule-cancel'>Return to 'Award Punishments'</a>
-            </div>
+        <a class="govuk-link" href=' {{ cancelHref }} ' data-qa='punishment-schedule-cancel'>Return to 'Award Punishments'</a>
+      </div>
 
-        </form>
-    </div>
+    </form>
+  </div>
 {% endblock %}


### PR DESCRIPTION
- Additional / prospective days punishment type - on punishment schedule page, radio buttons for whether the punishment is to be suspended or not are now visible, if user selects no then start and end dates do not have to be entered
- validation has also been changed in line with this
- stoppage percentage validation
- start and end date validation (end date not before start date)
- days entered must be more than 1
- date format on table (remove leading zero if day is less than 10)
- add 'award punishments' button on punishments tab if proved but no punishments yet
- add content on punishments tab for if report is not proved yet