### PR TITLE
NN-4601: Update and fix helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "express-request-id": "^1.4.1",
         "express-session": "^1.17.3",
         "govuk-frontend": "^4.6.0",
-        "helmet": "^4.6.0",
+        "helmet": "^6.1.5",
         "http-errors": "^2.0.0",
         "jquery": "^3.6.4",
         "jwt-decode": "^3.1.2",
@@ -7205,11 +7205,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
-      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.1.5.tgz",
+      "integrity": "sha512-UgAvdoG0BhF9vcCh/j0bWtElo2ZHHk6OzC98NLCM6zK03DEVSM0vUAtT7iR+oTo2Mi6sGelAH3tL6B/uUWxV4g==",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/hexoid": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "husky install",
     "copy-views": "cp -R server/views dist/server/",
-    "compile-sass": "sass --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend ./assets/sass/application.sass:./assets/stylesheets/application.css ./assets/sass/application-ie8.sass:./assets/stylesheets/application-ie8.css --style compressed",
+    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=. ./assets/sass/application.sass:./assets/stylesheets/application.css ./assets/sass/application-ie8.sass:./assets/stylesheets/application-ie8.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
     "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",
@@ -104,7 +104,7 @@
     "express-request-id": "^1.4.1",
     "express-session": "^1.17.3",
     "govuk-frontend": "^4.6.0",
-    "helmet": "^4.6.0",
+    "helmet": "^6.1.5",
     "http-errors": "^2.0.0",
     "jquery": "^3.6.4",
     "jwt-decode": "^3.1.2",

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -33,6 +33,7 @@ export default function setUpWebSecurity(): Router {
           connectSrc: ["'self'", '*.googletagmanager.com', '*.google-analytics.com', '*.analytics.google.com'],
         },
       },
+      crossOriginEmbedderPolicy: false,
     })
   )
   return router


### PR DESCRIPTION
We haven't been able to update the helmet dependency for a while because it broke something to do with the stylesheets, meaning our date pickers lost their styling.

This PR updates helmet to the most recent version and introduces a new key value pair within the web security file to fix the bug introduced before. The reason for it breaking was that the crossOriginEmbedderPolicy was set to true by default in the new version.

This also introduces a new flag which tells Sass not to emit deprecation warnings that come from dependencies and a new load-path flag.