### PR TITLE
NN-5199 filter prison ids and disable link

### DIFF
--- a/integration_tests/integration/prisonerSearch.cy.ts
+++ b/integration_tests/integration/prisonerSearch.cy.ts
@@ -95,11 +95,13 @@ context('Prisoner Search', () => {
           lastName: 'Smith',
           prisonerNumber: 'A1234AA',
           enhanced: false,
+          prisonId: 'LEI',
         }),
         testData.prisonerSearchSummary({
           firstName: 'John',
           lastName: 'Smith',
           prisonerNumber: 'A1234AA',
+          prisonId: 'MDI',
           enhanced: false,
         }),
       ],
@@ -110,7 +112,7 @@ context('Prisoner Search', () => {
     prisonerSearchPage.searchTermInput().type('A1234AA')
     prisonerSearchPage.submitButton().click()
     prisonerSearchPage.errorSummary().should('not.exist')
-    prisonerSearchPage.resultsRows().should('have.length', 2)
+    prisonerSearchPage.resultsRows().should('have.length', 1)
   })
 
   it('should have the correct href for the start a report link', () => {

--- a/server/routes/prisonerSelect/prisonerSelect.test.ts
+++ b/server/routes/prisonerSelect/prisonerSelect.test.ts
@@ -31,6 +31,7 @@ describe('GET /select-prisoner', () => {
         firstName: 'John',
         lastName: 'Smith',
         prisonerNumber: 'A1234AA',
+        prisonId: 'LEI',
         startHref: adjudicationUrls.incidentDetails.urls.start('A1234AA'),
       })
       return prisonerSearchService.search.mockResolvedValue([searchResult])

--- a/server/routes/prisonerSelect/prisonerSelect.ts
+++ b/server/routes/prisonerSelect/prisonerSelect.ts
@@ -37,7 +37,11 @@ export default class PrisonerSelectRoutes {
 
     if (!searchTerm) return res.redirect(adjudicationUrls.searchForPrisoner.root)
 
-    const searchResults = await this.prisonerSearchService.search({ searchTerm, prisonIds }, user)
+    let searchResults = await this.prisonerSearchService.search({ searchTerm, prisonIds }, user)
+
+    if (prisonIds.length === 0) {
+      searchResults = searchResults.filter(prisoner => prisoner.prisonId !== user.activeCaseLoadId)
+    }
 
     return this.renderView(req, res, { searchResults, searchTerm })
   }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -415,6 +415,7 @@ export default class TestData {
     enhanced = true,
     gender = 'Male',
     startHref = null,
+    prisonId = 'MDI',
   }: {
     firstName: string
     lastName: string
@@ -422,19 +423,21 @@ export default class TestData {
     enhanced?: boolean
     gender?: string
     startHref?: string
+    prisonId?: string
   }): PrisonerSearchSummary => {
     return {
       cellLocation: '1-2-015',
       prisonerNumber,
       prisonName: 'HMP Moorland',
       gender,
-      prisonId: 'MDI',
+      prisonId,
       firstName,
       lastName,
       startHref: enhanced ? startHref : null,
       displayCellLocation: enhanced ? '1-2-015' : null,
       displayName: enhanced ? `${lastName}, ${firstName}` : null,
       friendlyName: enhanced ? `${firstName} ${lastName}` : null,
+      onlyShowPrisonName: false,
     }
   }
 

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -13,6 +13,8 @@ export interface PrisonerSearchSummary extends PrisonerSearchResult {
   friendlyName: string
   displayCellLocation: string
   startHref: string
+  prisonName: string
+  onlyShowPrisonName: boolean
 }
 
 // Anything with a number is considered not to be a name, so therefore an identifier (prison no, PNC no etc.)
@@ -71,6 +73,7 @@ export default class PrisonerSearchService {
     const enhancedResults = results.map(prisoner => {
       return {
         ...prisoner,
+        onlyShowPrisonName: prisoner.prisonId !== user.activeCaseLoadId,
         ...PrisonerSearchService.enhancePrisoner(prisoner),
       }
     })

--- a/server/views/pages/prisonerSelect.njk
+++ b/server/views/pages/prisonerSelect.njk
@@ -32,7 +32,11 @@
       <img src="/prisoner/{{ prisoner.prisonerNumber }}/image" alt="Photograph of {{ prisoner.displayName }}" class="results-table__image" />
     {% endset -%}
     {% set prisonerLinkHtml %}
+     {% if prisoner.onlyShowPrisonName %}
+      {{ prisoner.prisonName }}
+    {% else %}
       <a href="{{ digitalPrisonServiceUrl }}/prisoner/{{ prisoner.prisonerNumber }}" class="govuk-link">View profile</a>
+        {% endif %}
     {% endset -%}
     {% set startReportlLinkHtml %}
       <a href="{{ prisoner.startHref }}" class="govuk-link" data-qa="start-report-link">Start a report<span class="govuk-visually-hidden">for {{ prisoner.friendlyName }}</span></a>


### PR DESCRIPTION
when searching transfers, now filters out prisoners in activecaseload, and replaces profile href with name of prison, as without global search, a user can not see profile 