### PR TITLE
NN-5189: Get agencies for incident and hearing

### DIFF
--- a/integration_tests/integration/aloEditOffence.cy.ts
+++ b/integration_tests/integration/aloEditOffence.cy.ts
@@ -283,6 +283,8 @@ context('ALO edits offence - test 1', () => {
       adjudicationNumber: 177,
       response: editedReportedAdjudicationTestOne,
     })
+    cy.task('stubGetAgency', { agencyId: 'MDI', response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' } })
+
     cy.signIn()
   })
   it('allows ALO to update the adjudication offence - from assist to commit etc', () => {
@@ -427,6 +429,8 @@ context('ALO edits offence - test 2', () => {
       adjudicationNumber: 188,
       response: editedReportedAdjudicationTestTwo,
     })
+    cy.task('stubGetAgency', { agencyId: 'MDI', response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' } })
+
     cy.signIn()
   })
 

--- a/integration_tests/integration/hearingTab.cy.ts
+++ b/integration_tests/integration/hearingTab.cy.ts
@@ -55,6 +55,7 @@ const hearingWithAdjournedOutcome = testData.singleHearing({
   id: 988,
   locationId: 234,
   oicHearingType: OicHearingType.INAD_ADULT,
+  agencyId: 'MDI',
   outcome: {
     id: 123,
     adjudicator: 'Judge Green',
@@ -81,6 +82,7 @@ const hearingWithReferToPoliceOutcome = testData.singleHearing({
   dateTimeOfHearing: hearingDateTimeTwo,
   id: 988,
   locationId: 234,
+  agencyId: 'LEI',
   oicHearingType: OicHearingType.INAD_ADULT,
   outcome: testData.hearingOutcome({ optionalItems: { details: 'This is my reason for referring.' } }),
 })
@@ -642,6 +644,14 @@ context('Hearing details page', () => {
         true
       ),
     })
+    cy.task('stubGetAgency', {
+      agencyId: 'MDI',
+      response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' },
+    })
+    cy.task('stubGetAgency', {
+      agencyId: 'LEI',
+      response: { agencyId: 'LEI', description: 'Leeds (HMP)' },
+    })
     cy.signIn()
   })
   describe('Test scenarios - reviewer view', () => {
@@ -928,7 +938,7 @@ context('Hearing details page', () => {
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeOneFormatted)
           expect($summaryData.get(1).innerText).to.contain('Change')
-          expect($summaryData.get(2).innerText).to.contain('Adj 1')
+          expect($summaryData.get(2).innerText).to.contain('Adj 1, Moorland (HMP & YOI)')
           expect($summaryData.get(3).innerText).to.contain('Change')
           expect($summaryData.get(4).innerText).to.contain('Governor')
           expect($summaryData.get(5).innerText).to.contain('Change')
@@ -960,7 +970,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Green')
           expect($summaryData.get(4).innerText).to.contain('Change')
@@ -1041,7 +1051,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Green')
           expect($summaryData.get(4).innerText).to.contain('Adjourn the hearing for another reason')
@@ -1054,7 +1064,7 @@ context('Hearing details page', () => {
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeOneFormatted)
           expect($summaryData.get(1).innerText).to.contain('Change')
-          expect($summaryData.get(2).innerText).to.contain('Adj 1')
+          expect($summaryData.get(2).innerText).to.contain('Adj 1, Moorland (HMP & YOI)')
           expect($summaryData.get(3).innerText).to.contain('Change')
           expect($summaryData.get(4).innerText).to.contain('Governor')
           expect($summaryData.get(5).innerText).to.contain('Change')
@@ -1132,7 +1142,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Green')
           expect($summaryData.get(4).innerText).to.contain('Change')
@@ -1167,7 +1177,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Leeds (HMP)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the police')
@@ -1204,7 +1214,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Leeds (HMP)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the police')
@@ -1276,7 +1286,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Leeds (HMP)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the police')
@@ -1318,7 +1328,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
@@ -1351,7 +1361,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
@@ -1383,7 +1393,7 @@ context('Hearing details page', () => {
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeThreeFormatted)
           expect($summaryData.get(1).innerText).to.contain('Change')
-          expect($summaryData.get(2).innerText).to.contain('Adj 1')
+          expect($summaryData.get(2).innerText).to.contain('Adj 1, Moorland (HMP & YOI)')
           expect($summaryData.get(3).innerText).to.contain('Change')
           expect($summaryData.get(4).innerText).to.contain('Governor')
         })
@@ -1409,7 +1419,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeThreeFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Change')
@@ -1447,7 +1457,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeThreeFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Governor')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Change')
@@ -1485,7 +1495,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeThreeFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Governor')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Change')
@@ -1696,7 +1706,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Governor')
         })
       hearingTabPage.scheduleAnotherHearingButton().should('not.exist')
@@ -1712,7 +1722,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
@@ -1738,7 +1748,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Governor')
         })
       hearingTabPage.scheduleAnotherHearingButton().should('not.exist')
@@ -1841,7 +1851,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeOneFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 1')
+          expect($summaryData.get(1).innerText).to.contain('Adj 1, Moorland (HMP & YOI)')
         })
     })
     it('Adjudication SCHEDULED multiple hearings to show', () => {
@@ -1867,7 +1877,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Green')
           expect($summaryData.get(4).innerText).to.contain('Adjourn the hearing for another reason')
@@ -1879,7 +1889,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeOneFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 1')
+          expect($summaryData.get(1).innerText).to.contain('Adj 1, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Governor')
         })
       hearingTabPage.changeLink().should('not.exist')
@@ -1893,7 +1903,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeTwoFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 2')
+          expect($summaryData.get(1).innerText).to.contain('Adj 2, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Independent Adjudicator')
           expect($summaryData.get(3).innerText).to.contain('J. Red')
           expect($summaryData.get(4).innerText).to.contain('Refer this case to the independent adjudicator')
@@ -1924,7 +1934,7 @@ context('Hearing details page', () => {
         .find('dd')
         .then($summaryData => {
           expect($summaryData.get(0).innerText).to.contain(hearingDateTimeThreeFormatted)
-          expect($summaryData.get(1).innerText).to.contain('Adj 1')
+          expect($summaryData.get(1).innerText).to.contain('Adj 1, Moorland (HMP & YOI)')
           expect($summaryData.get(2).innerText).to.contain('Governor')
         })
     })

--- a/integration_tests/integration/prisonerReportReporter_afterAcceptance.cy.ts
+++ b/integration_tests/integration/prisonerReportReporter_afterAcceptance.cy.ts
@@ -168,6 +168,7 @@ context('Prisoner report - reporter view', () => {
         authSource: 'auth',
       },
     })
+    cy.task('stubGetAgency', { agencyId: 'MDI', response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' } })
     return cy.signIn()
   })
   describe('Status ACCEPTED [legacy to check for backwards compatibility]', () => {
@@ -230,7 +231,7 @@ context('Prisoner report - reporter view', () => {
           expect($summaryData.get(0).innerText).to.contain('T. User')
           expect($summaryData.get(1).innerText).to.contain('9 December 2021')
           expect($summaryData.get(2).innerText).to.contain('10:30')
-          expect($summaryData.get(3).innerText).to.contain('Houseblock 1')
+          expect($summaryData.get(3).innerText).to.contain('Houseblock 1, Moorland (HMP & YOI)')
         })
     })
     it('should contain the correct offence details', () => {
@@ -375,7 +376,7 @@ context('Prisoner report - reporter view', () => {
           expect($summaryData.get(0).innerText).to.contain('T. User')
           expect($summaryData.get(1).innerText).to.contain('9 December 2021')
           expect($summaryData.get(2).innerText).to.contain('10:30')
-          expect($summaryData.get(3).innerText).to.contain('Houseblock 1')
+          expect($summaryData.get(3).innerText).to.contain('Houseblock 1, Moorland (HMP & YOI)')
         })
     })
     it('should contain the correct offence details', () => {

--- a/integration_tests/integration/prisonerReportReporter_beforeAcceptance.cy.ts
+++ b/integration_tests/integration/prisonerReportReporter_beforeAcceptance.cy.ts
@@ -186,6 +186,11 @@ context('Prisoner report - reporter view', () => {
         authSource: 'auth',
       },
     })
+    cy.task('stubGetAgency', {
+      agencyId: 'MDI',
+      response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' },
+    })
+
     return cy.signIn()
   })
   describe('Report status AWAITING_REVIEW', () => {

--- a/integration_tests/integration/prisonerReportReviewer_afterAcceptance.cy.ts
+++ b/integration_tests/integration/prisonerReportReviewer_afterAcceptance.cy.ts
@@ -144,6 +144,8 @@ context('Prisoner report - reviewer view', () => {
         jsonBody: {},
       },
     })
+    cy.task('stubGetAgency', { agencyId: 'MDI', response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' } })
+
     cy.signIn()
   })
   describe('report UNSCHEDULED', () => {

--- a/integration_tests/integration/prisonerReportReviewer_beforeAcceptance.cy.ts
+++ b/integration_tests/integration/prisonerReportReviewer_beforeAcceptance.cy.ts
@@ -191,6 +191,8 @@ context('Prisoner report - reviewer view', () => {
         jsonBody: {},
       },
     })
+    cy.task('stubGetAgency', { agencyId: 'MDI', response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' } })
+
     cy.signIn()
   })
   describe('report AWAITING REVIEW', () => {

--- a/integration_tests/integration/prisonerReportTransfer_viewOnly.cy.ts
+++ b/integration_tests/integration/prisonerReportTransfer_viewOnly.cy.ts
@@ -171,6 +171,10 @@ context('Prisoner report - view only - for transferred prisoners', () => {
         authSource: 'auth',
       },
     })
+    cy.task('stubGetAgency', {
+      agencyId: 'MDI',
+      response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' },
+    })
     return cy.signIn()
   })
   describe('Status UNSCHEDULED', () => {

--- a/integration_tests/integration/transfersFlow.cy.ts
+++ b/integration_tests/integration/transfersFlow.cy.ts
@@ -206,6 +206,10 @@ context('Transfers flow', () => {
         cy.task('stubGetMovementByOffender', {
           response: testData.prisonerMovement({}),
         })
+        cy.task('stubGetAgency', {
+          agencyId: 'MDI',
+          response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' },
+        })
       })
       it('all reports to prisoner report, tabs go to correct places', () => {
         cy.visit(adjudicationUrls.allCompletedReports.root)
@@ -450,6 +454,10 @@ context('Transfers flow', () => {
           response: {
             reportedAdjudication: transferredPrisonersAdjudicationProvedPunishments,
           },
+        })
+        cy.task('stubGetAgency', {
+          agencyId: 'MDI',
+          response: { agencyId: 'MDI', description: 'Moorland (HMP & YOI)' },
         })
       })
       it('all reports to prisoner report, tabs go to correct places', () => {

--- a/server/routes/adjudicationForReport/hearingTab/hearingTabReviewer.test.ts
+++ b/server/routes/adjudicationForReport/hearingTab/hearingTabReviewer.test.ts
@@ -111,23 +111,6 @@ describe('GET hearing details page - reviewer version', () => {
 })
 describe('POST cancel hearing', () => {
   it('should call the cancel endpoint if user cancels a hearing', () => {
-    reportedAdjudicationsService.getHearingDetails.mockResolvedValue([
-      {
-        id: 101,
-        dateTime: {
-          label: 'Date and time of hearing',
-          value: '24 October 2022 - 12:54',
-        },
-        location: {
-          label: 'Location',
-          value: 'Adj 2',
-        },
-        type: {
-          label: 'Type of hearing',
-          value: 'Governor',
-        },
-      },
-    ])
     return request(app)
       .post(adjudicationUrls.hearingDetails.urls.review(1524494))
       .send({ removeHearingButton: 'cancelHearingButton-101' })

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -145,6 +145,7 @@ export default class TestData {
     incidentStatement = {} as IncidentStatement,
     isYouthOffender = false,
     startedByUserId = 'USER1',
+    originatingAgencyId = 'MDI',
     otherData = {} as any,
   }: {
     id: number
@@ -162,6 +163,7 @@ export default class TestData {
     incidentStatement?: IncidentStatement
     isYouthOffender?: boolean
     startedByUserId?: string
+    originatingAgencyId?: string
     otherData?: any
   }) => {
     return {
@@ -183,6 +185,7 @@ export default class TestData {
       evidence,
       witnesses,
       isYouthOffender,
+      originatingAgencyId,
       ...otherData,
     }
   }

--- a/server/services/reportedAdjudicationsService.test.ts
+++ b/server/services/reportedAdjudicationsService.test.ts
@@ -8,7 +8,6 @@ import CuriousApiService from './curiousApiService'
 import LocationService from './locationService'
 import {
   IssueStatus,
-  OicHearingType,
   ReportedAdjudicationDISFormFilter,
   ReportedAdjudicationStatus,
 } from '../data/ReportedAdjudicationResult'

--- a/server/services/reportedAdjudicationsService.test.ts
+++ b/server/services/reportedAdjudicationsService.test.ts
@@ -464,7 +464,7 @@ describe('reportedAdjudicationsService', () => {
           },
           {
             label: 'Location',
-            value: 'Closed Visits',
+            value: 'Closed Visits, Moorland (HMP & YOI)',
           },
           {
             label: 'Date of discovery',
@@ -612,132 +612,6 @@ describe('reportedAdjudicationsService', () => {
       expect(result).toEqual(expectedResult)
     })
   })
-  describe('getHearingDetails', () => {
-    it('returns the correct information multiple hearings', async () => {
-      const hearings = [
-        {
-          ...testData.singleHearing({
-            dateTimeOfHearing: '2022-10-20T11:11:00',
-            id: 1234,
-          }),
-          locationId: 27187,
-        },
-        {
-          ...testData.singleHearing({
-            dateTimeOfHearing: '2022-10-21T11:11:00',
-            id: 23445,
-          }),
-          locationId: 27187,
-        },
-      ]
-      const result = await service.getHearingDetails(hearings, user)
-      const expectedResult = [
-        {
-          id: 1234,
-          dateTime: {
-            label: 'Date and time of hearing',
-            value: '20 October 2022 - 11:11',
-          },
-          location: {
-            label: 'Location',
-            value: 'Adj',
-          },
-          type: {
-            label: 'Type of hearing',
-            value: 'Governor',
-          },
-        },
-        {
-          id: 23445,
-          dateTime: {
-            label: 'Date and time of hearing',
-            value: '21 October 2022 - 11:11',
-          },
-          location: {
-            label: 'Location',
-            value: 'Adj',
-          },
-          type: {
-            label: 'Type of hearing',
-            value: 'Governor',
-          },
-        },
-      ]
-      expect(result).toEqual(expectedResult)
-    })
-    it('returns the correct information for one hearing', async () => {
-      const hearings = [
-        { ...testData.singleHearing({ dateTimeOfHearing: '2022-10-20T11:11:00', id: 1234 }), locationId: 27187 },
-      ]
-      const result = await service.getHearingDetails(hearings, user)
-      const expectedResult = [
-        {
-          id: 1234,
-          dateTime: {
-            label: 'Date and time of hearing',
-            value: '20 October 2022 - 11:11',
-          },
-          location: {
-            label: 'Location',
-            value: 'Adj',
-          },
-          type: {
-            label: 'Type of hearing',
-            value: 'Governor',
-          },
-        },
-      ]
-      expect(result).toEqual(expectedResult)
-    })
-    it('returns the correct information for no hearings', async () => {
-      const result = await service.getHearingDetails([], user)
-      expect(result).toEqual([])
-    })
-  })
-  describe('getAllHearings', () => {
-    const batchPrisonerDetails = [
-      testData.simplePrisoner('G6123VU', 'JOHN', 'SMITH', '1-0-015'),
-      testData.simplePrisoner('G6174VU', 'James', 'Moriarty', '1-0-015'),
-    ]
-    it('deals with no hearings', async () => {
-      getHearingsGivenAgencyAndDate.mockResolvedValue({ hearings: [] })
-      getBatchPrisonerDetails.mockResolvedValue(batchPrisonerDetails)
-      const result = await service.getAllHearings('2022-10-19', user)
-      expect(result).toEqual([])
-    })
-    it('mapipulates data correctly', async () => {
-      getHearingsGivenAgencyAndDate.mockResolvedValue({
-        hearings: [
-          {
-            ...testData.singleHearing({
-              dateTimeOfHearing: '2022-11-14T11:00:00',
-              id: 1234,
-            }),
-            dateTimeOfDiscovery: '2022-11-11T09:00:00',
-            prisonerNumber: 'G6123VU',
-            adjudicationNumber: 123456,
-          },
-        ],
-      })
-      getBatchPrisonerDetails.mockResolvedValue(batchPrisonerDetails)
-      const result = await service.getAllHearings('2022-11-14', user)
-      expect(result).toEqual([
-        {
-          id: 1234,
-          adjudicationNumber: 123456,
-          dateTimeOfDiscovery: '2022-11-11T09:00:00',
-          dateTimeOfHearing: '2022-11-14T11:00:00',
-          formattedDateTimeOfHearing: '14 November 2022 - 11:00',
-          friendlyName: 'John Smith',
-          nameAndNumber: 'Smith, John - G6123VU',
-          oicHearingType: OicHearingType.GOV_ADULT as string,
-          prisonerNumber: 'G6123VU',
-          locationId: 775,
-          agencyId: 'MDI',
-        },
-      ])
-    })
-  })
   describe('getAdjudicationDISFormData', () => {
     it('success - confirm DIS1/2 has been issued page', async () => {
       getReportedAdjudicationIssueData.mockResolvedValue({
@@ -751,7 +625,6 @@ describe('reportedAdjudicationsService', () => {
         ],
       })
       getBatchPrisonerDetails.mockResolvedValue([testData.simplePrisoner('G6123VU', 'JOHN', 'SMITH', '1-0-015')])
-      // getAlertsForPrisoner.mockResolvedValue([])
       const defaultFilter: ReportedAdjudicationDISFormFilter = {
         fromDate: moment('03/02/2023', 'DD/MM/YYYY'),
         toDate: moment('05/02/2021', 'DD/MM/YYYY'),

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -26,7 +26,6 @@ import {
   formatLocation,
   formatTimestampTo,
   formatName,
-  convertOicHearingType,
 } from '../utils/utils'
 import { LocationId } from '../data/PrisonLocationResult'
 import {


### PR DESCRIPTION
Uses the agency on the adjudication (originatingAgencyId) to get agency name and display on prisoner report.
Uses the agencyId listed on the hearing to get agency name to display on hearings page