### PR TITLE
NN-5270: Refactor & check for hearing type on manual susp radios

### DIFF
--- a/integration_tests/integration/manuallyActivateSuspendedPunishment.cy.ts
+++ b/integration_tests/integration/manuallyActivateSuspendedPunishment.cy.ts
@@ -7,7 +7,7 @@ import AwardPunishmentsPage from '../pages/awardPunishments'
 import CheckPunishmentsPage from '../pages/checkPunishments'
 import PunishmentsAndDamagesPage from '../pages/punishmentsAndDamages'
 import { forceDateInput } from '../componentDrivers/dateInput'
-import { ReportedAdjudicationStatus } from '../../server/data/ReportedAdjudicationResult'
+import { OicHearingType, ReportedAdjudicationStatus } from '../../server/data/ReportedAdjudicationResult'
 import { PrivilegeType, PunishmentType } from '../../server/data/PunishmentResult'
 import { HearingOutcomeCode, OutcomeCode } from '../../server/data/HearingAndOutcomeResult'
 
@@ -45,6 +45,25 @@ context('Manually activate an existing suspended punishment', () => {
                 }),
               },
             },
+          ],
+        }),
+      },
+    })
+    cy.task('stubGetReportedAdjudication', {
+      id: 101,
+      response: {
+        reportedAdjudication: testData.reportedAdjudication({
+          adjudicationNumber: 101,
+          status: ReportedAdjudicationStatus.CHARGE_PROVED,
+          prisonerNumber: 'G6415GD',
+          hearings: [
+            testData.singleHearing({
+              dateTimeOfHearing: '2023-03-10T22:00:00',
+              oicHearingType: OicHearingType.INAD_ADULT,
+              outcome: testData.hearingOutcome({
+                code: HearingOutcomeCode.COMPLETE,
+              }),
+            }),
           ],
         }),
       },
@@ -88,6 +107,8 @@ context('Manually activate an existing suspended punishment', () => {
       punishmentPage.submitButton().should('exist')
       punishmentPage.cancelButton().should('exist')
       punishmentPage.punishment().should('exist')
+      cy.get('#punishmentType-8').should('not.exist')
+      cy.get('#punishmentType-9').should('not.exist')
     })
     it('cancel link goes back to punishments page', () => {
       cy.visit(adjudicationUrls.manuallyActivateSuspendedPunishment.urls.start(100))
@@ -96,6 +117,13 @@ context('Manually activate an existing suspended punishment', () => {
       cy.location().should(loc => {
         expect(loc.pathname).to.eq(adjudicationUrls.awardPunishments.urls.modified(100))
       })
+    })
+    it('should show additional days and prospective additional days radios if the hearing is IA', () => {
+      cy.visit(adjudicationUrls.punishment.urls.start(101))
+      cy.get('#punishmentType-8').should('exist')
+      cy.get('[for="punishmentType-8"]').should('include.text', 'Additional days')
+      cy.get('#punishmentType-9').should('exist')
+      cy.get('[for="punishmentType-9"]').should('include.text', 'Prospective additional days')
     })
   })
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -287,10 +287,7 @@ export default function routes(
     punishmentsAndDamagesRoutes({ reportedAdjudicationsService, userService, punishmentsService })
   )
   router.use(adjudicationUrls.punishmentComment.root, PunishmentCommentRoutes({ userService, punishmentsService }))
-  router.use(
-    adjudicationUrls.punishment.root,
-    PunishmentRoutes({ userService, punishmentsService, reportedAdjudicationsService })
-  )
+  router.use(adjudicationUrls.punishment.root, PunishmentRoutes({ userService, punishmentsService }))
   router.use(adjudicationUrls.punishmentSchedule.root, PunishmentScheduleRoutes({ userService, punishmentsService }))
 
   router.use(adjudicationUrls.awardPunishments.root, awardPunishmentsRoutes({ punishmentsService, userService }))

--- a/server/routes/punishment/index.ts
+++ b/server/routes/punishment/index.ts
@@ -7,21 +7,18 @@ import PunishmentEditRoute from './punishmentEdit'
 import UserService from '../../services/userService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import PunishmentsService from '../../services/punishmentsService'
-import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 
 export default function PunishmentRoutes({
   userService,
   punishmentsService,
-  reportedAdjudicationsService,
 }: {
   userService: UserService
   punishmentsService: PunishmentsService
-  reportedAdjudicationsService: ReportedAdjudicationsService
 }): Router {
   const router = express.Router()
 
-  const punishmentRoute = new PunishmentRoute(userService, punishmentsService, reportedAdjudicationsService)
-  const punishmentEditRoute = new PunishmentEditRoute(userService, punishmentsService, reportedAdjudicationsService)
+  const punishmentRoute = new PunishmentRoute(userService, punishmentsService)
+  const punishmentEditRoute = new PunishmentEditRoute(userService, punishmentsService)
 
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))

--- a/server/routes/punishment/punishment.ts
+++ b/server/routes/punishment/punishment.ts
@@ -2,22 +2,12 @@ import { Request, Response } from 'express'
 import PunishmentPage, { PageRequestType } from './punishmentPage'
 import UserService from '../../services/userService'
 import PunishmentsService from '../../services/punishmentsService'
-import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 
 export default class PunishmentRoute {
   page: PunishmentPage
 
-  constructor(
-    private readonly userService: UserService,
-    private readonly punishmentsService: PunishmentsService,
-    private readonly reportedAdjudicationsService: ReportedAdjudicationsService
-  ) {
-    this.page = new PunishmentPage(
-      PageRequestType.CREATION,
-      userService,
-      punishmentsService,
-      reportedAdjudicationsService
-    )
+  constructor(private readonly userService: UserService, private readonly punishmentsService: PunishmentsService) {
+    this.page = new PunishmentPage(PageRequestType.CREATION, userService, punishmentsService)
   }
 
   view = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/punishment/punishmentEdit.ts
+++ b/server/routes/punishment/punishmentEdit.ts
@@ -2,17 +2,12 @@ import { Request, Response } from 'express'
 import PunishmentPage, { PageRequestType } from './punishmentPage'
 import UserService from '../../services/userService'
 import PunishmentsService from '../../services/punishmentsService'
-import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 
 export default class PunishmentEditRoute {
   page: PunishmentPage
 
-  constructor(
-    private readonly userService: UserService,
-    private readonly punishmentsService: PunishmentsService,
-    private readonly reportedAdjudicationsService: ReportedAdjudicationsService
-  ) {
-    this.page = new PunishmentPage(PageRequestType.EDIT, userService, punishmentsService, reportedAdjudicationsService)
+  constructor(private readonly userService: UserService, private readonly punishmentsService: PunishmentsService) {
+    this.page = new PunishmentPage(PageRequestType.EDIT, userService, punishmentsService)
   }
 
   view = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/punishment/punishmentPage.ts
+++ b/server/routes/punishment/punishmentPage.ts
@@ -8,7 +8,6 @@ import { hasAnyRole } from '../../utils/utils'
 import adjudicationUrls from '../../utils/urlGenerator'
 import { PrivilegeType, PunishmentType } from '../../data/PunishmentResult'
 import PunishmentsService from '../../services/punishmentsService'
-import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import config from '../../config'
 
 type PageData = {
@@ -38,8 +37,7 @@ export default class PunishmentPage {
   constructor(
     pageType: PageRequestType,
     private readonly userService: UserService,
-    private readonly punishmentsService: PunishmentsService,
-    private readonly reportedAdjudicationsService: ReportedAdjudicationsService
+    private readonly punishmentsService: PunishmentsService
   ) {
     this.pageOptions = new PageOptions(pageType)
   }
@@ -49,8 +47,10 @@ export default class PunishmentPage {
     const { user } = res.locals
     const { error, punishmentType, privilegeType, otherPrivilege, stoppagePercentage } = pageData
 
-    const lastHearing = await this.reportedAdjudicationsService.getLatestHearing(adjudicationNumber, user)
-    const isIndependentAdjudicatorHearing = lastHearing.oicHearingType.includes('INAD')
+    const isIndependentAdjudicatorHearing = await this.punishmentsService.checkAdditionalDaysAvailability(
+      adjudicationNumber,
+      user
+    )
 
     return res.render(`pages/punishment.njk`, {
       cancelHref: adjudicationUrls.awardPunishments.urls.modified(adjudicationNumber),

--- a/server/routes/punishments/manuallyActivateSuspendedPunishments/manuallyActivateSuspendedPunishmentsPage.ts
+++ b/server/routes/punishments/manuallyActivateSuspendedPunishments/manuallyActivateSuspendedPunishmentsPage.ts
@@ -24,10 +24,13 @@ export default class ManuallyActivateSuspendedPunishmentsPage {
 
   private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
     const adjudicationNumber = Number(req.params.adjudicationNumber)
+    const { user } = res.locals
     const { error, punishmentType, privilegeType, otherPrivilege, stoppagePercentage, reportNumber } = pageData
 
-    // This is a placeholder until NN-5270
-    const isIndependentAdjudicatorHearing = false
+    const isIndependentAdjudicatorHearing = await this.punishmentsService.checkAdditionalDaysAvailability(
+      adjudicationNumber,
+      user
+    )
 
     return res.render(`pages/manuallyActivateSuspendedPunishment.njk`, {
       awardPunishmentsHref: adjudicationUrls.awardPunishments.urls.modified(adjudicationNumber),

--- a/server/services/punishmentsService.ts
+++ b/server/services/punishmentsService.ts
@@ -152,4 +152,13 @@ export default class PunishmentsService {
   ): Promise<ReportedAdjudicationResult> {
     return new ManageAdjudicationsClient(user).removePunishmentComment(adjudicationNumber, id)
   }
+
+  async checkAdditionalDaysAvailability(adjudicationNumber: number, user: User): Promise<boolean> {
+    const { reportedAdjudication } = await new ManageAdjudicationsClient(user).getReportedAdjudication(
+      adjudicationNumber
+    )
+    if (!reportedAdjudication.hearings?.length) return false
+    const lastHearing = reportedAdjudication.hearings[reportedAdjudication.hearings.length - 1]
+    return lastHearing.oicHearingType.includes('INAD')
+  }
 }


### PR DESCRIPTION
Refactor to check that the OicHearingType of final hearing is IA within the punishments service - removing requirement of access to the reportedAdjudicationsService file. This function is tested.
This function is called in the add punishment file and in the manually add suspended punishments file