### PR TITLE
NN-5261

### DIFF
--- a/integration_tests/integration/awardPunishmentsStartAndEdit.cy.ts
+++ b/integration_tests/integration/awardPunishmentsStartAndEdit.cy.ts
@@ -6,6 +6,7 @@ import ActivateSuspendedPunishmentsPage from '../pages/activateSuspendedPunishme
 import SuspendedPunishmentSchedule from '../pages/suspendedPunishmentSchedule'
 import AwardPunishmentsPage from '../pages/awardPunishments'
 import PunishmentSchedulePage from '../pages/punishmentSchedule'
+import NumberOfAdditionalDaysPage from '../pages/numberOfAdditionalDays'
 import { forceDateInput } from '../componentDrivers/dateInput'
 import { PrivilegeType, PunishmentType } from '../../server/data/PunishmentResult'
 import { OicHearingType, ReportedAdjudicationStatus } from '../../server/data/ReportedAdjudicationResult'
@@ -268,7 +269,8 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       punishmentSchedulePage.submitButton().click()
     })
 
-    it('create and edit punishments - PROSPECTIVE DAYS', () => {
+    // skipped until the additional days flow is completed
+    it.skip('create and edit punishments - PROSPECTIVE DAYS', () => {
       cy.visit(adjudicationUrls.awardPunishments.urls.start(101))
       const awardPunishmentsPage = Page.verifyOnPage(AwardPunishmentsPage)
 
@@ -279,12 +281,9 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
 
       punishmentPage.submitButton().click()
 
-      const punishmentSchedulePage = Page.verifyOnPage(PunishmentSchedulePage)
-      punishmentSchedulePage.suspended().should('exist')
-      punishmentSchedulePage.days().type('10')
-      punishmentSchedulePage.suspended().find('input[value="no"]').click()
-
-      punishmentSchedulePage.submitButton().click()
+      const numberOfAdditionalDaysPage = Page.verifyOnPage(NumberOfAdditionalDaysPage)
+      numberOfAdditionalDaysPage.days().type('10')
+      numberOfAdditionalDaysPage.submitButton().click()
 
       awardPunishmentsPage.editPunishment().first().click()
 
@@ -292,9 +291,9 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
 
       punishmentPage.submitButton().click()
 
-      punishmentSchedulePage.days().should('have.value', '10')
+      numberOfAdditionalDaysPage.days().should('have.value', '10')
 
-      punishmentSchedulePage.submitButton().click()
+      numberOfAdditionalDaysPage.submitButton().click()
     })
 
     it('Activate a suspended punishment and include report number in correct column, remove change link', () => {

--- a/integration_tests/integration/numberOfAdditionalDays.cy.ts
+++ b/integration_tests/integration/numberOfAdditionalDays.cy.ts
@@ -1,0 +1,75 @@
+import Page from '../pages/page'
+import adjudicationUrls from '../../server/utils/urlGenerator'
+import TestData from '../../server/routes/testutils/testData'
+import NumberOfAdditionalDaysPage from '../pages/numberOfAdditionalDays'
+
+const testData = new TestData()
+context('Number of additional days', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+    cy.task('stubGetUserFromUsername', {
+      username: 'USER1',
+      response: testData.userFromUsername(),
+    })
+    cy.task('stubUserRoles', [{ roleCode: 'ADJUDICATIONS_REVIEWER' }])
+    cy.signIn()
+  })
+  describe('Loads', () => {
+    it('should contain the required page elements', () => {
+      cy.visit(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      const numberOfAdditionalDaysPage = Page.verifyOnPage(NumberOfAdditionalDaysPage)
+      numberOfAdditionalDaysPage.submitButton().should('exist')
+      numberOfAdditionalDaysPage.cancelButton().should('exist')
+      numberOfAdditionalDaysPage.days().should('exist')
+    })
+    it('cancel link goes back to punishments page', () => {
+      cy.visit(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      const numberOfAdditionalDaysPage = Page.verifyOnPage(NumberOfAdditionalDaysPage)
+      numberOfAdditionalDaysPage.cancelButton().click()
+      cy.location().should(loc => {
+        expect(loc.pathname).to.eq(adjudicationUrls.awardPunishments.urls.modified(100))
+      })
+    })
+  })
+  describe('Validation', () => {
+    it('should error when no days entered', () => {
+      cy.visit(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      const numberOfAdditionalDaysPage = Page.verifyOnPage(NumberOfAdditionalDaysPage)
+      numberOfAdditionalDaysPage.submitButton().click()
+
+      numberOfAdditionalDaysPage
+        .errorSummary()
+        .find('li')
+        .then($error => {
+          expect($error.get(0).innerText).to.contain('Enter how many days the punishment will last')
+        })
+    })
+    it('should error when something other than a number over 1 is entered', () => {
+      cy.visit(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      const numberOfAdditionalDaysPage = Page.verifyOnPage(NumberOfAdditionalDaysPage)
+      numberOfAdditionalDaysPage.days().type('l')
+      numberOfAdditionalDaysPage.submitButton().click()
+
+      numberOfAdditionalDaysPage
+        .errorSummary()
+        .find('li')
+        .then($error => {
+          expect($error.get(0).innerText).to.contain('Enter a number of days')
+        })
+    })
+  })
+
+  describe('saves successfully and redirects', () => {
+    it('should redirect when days are entered correctly', () => {
+      cy.visit(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      const numberOfAdditionalDaysPage = Page.verifyOnPage(NumberOfAdditionalDaysPage)
+      numberOfAdditionalDaysPage.days().type('10')
+      numberOfAdditionalDaysPage.submitButton().click()
+      cy.location().should(loc => {
+        expect(loc.pathname).to.eq(adjudicationUrls.isPunishmentSuspended.urls.start(100))
+      })
+    })
+  })
+})

--- a/integration_tests/pages/numberOfAdditionalDays.ts
+++ b/integration_tests/pages/numberOfAdditionalDays.ts
@@ -1,0 +1,15 @@
+import Page, { PageElement } from './page'
+
+export default class NumberOfAdditionalDaysPage extends Page {
+  constructor() {
+    super('Enter the number of additional days')
+  }
+
+  days = (): PageElement => cy.get('input[id="days"]')
+
+  submitButton = (): PageElement => cy.get('[data-qa="submit"]')
+
+  cancelButton = (): PageElement => cy.get('[data-qa="cancel"]')
+
+  errorSummary = (): PageElement => cy.get('[data-qa="error-summary"]')
+}

--- a/integration_tests/pages/numberOfAdditionalDays.ts
+++ b/integration_tests/pages/numberOfAdditionalDays.ts
@@ -5,7 +5,7 @@ export default class NumberOfAdditionalDaysPage extends Page {
     super('Enter the number of additional days')
   }
 
-  days = (): PageElement => cy.get('input[id="days"]')
+  days = (): PageElement => cy.get('input[id="numberOfDays"]')
 
   submitButton = (): PageElement => cy.get('[data-qa="submit"]')
 

--- a/server/routes/adjudicationForReport/prisonerReport/prisonerReport.test.ts
+++ b/server/routes/adjudicationForReport/prisonerReport/prisonerReport.test.ts
@@ -138,7 +138,7 @@ afterEach(() => {
 })
 
 describe('GET prisoner report', () => {
-  it.only('should load the prisoner report page', () => {
+  it('should load the prisoner report page', () => {
     return request(app)
       .get(adjudicationUrls.prisonerReport.urls.report(12345))
       .expect('Content-Type', /html/)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -290,11 +290,12 @@ export default function routes(
   router.use(adjudicationUrls.punishmentComment.root, PunishmentCommentRoutes({ userService, punishmentsService }))
   router.use(adjudicationUrls.punishment.root, PunishmentRoutes({ userService, punishmentsService }))
   router.use(adjudicationUrls.punishmentSchedule.root, PunishmentScheduleRoutes({ userService, punishmentsService }))
-  router.use(
-    adjudicationUrls.numberOfAdditionalDays.root,
-    NumberOfAdditionalDaysRoutes({ userService, punishmentsService })
-  )
-
+  if (config.addedDaysFlag === 'true') {
+    router.use(
+      adjudicationUrls.numberOfAdditionalDays.root,
+      NumberOfAdditionalDaysRoutes({ userService, punishmentsService })
+    )
+  }
   router.use(adjudicationUrls.awardPunishments.root, awardPunishmentsRoutes({ punishmentsService, userService }))
   router.use(adjudicationUrls.checkPunishments.root, checkPunishmentRoutes({ punishmentsService, userService }))
   router.use(

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -67,6 +67,7 @@ import PunishmentCommentRoutes from './punishmentComment'
 import PunishmentRoutes from './punishment'
 import awardPunishmentsRoutes from './punishments/awardPunishments'
 import PunishmentScheduleRoutes from './punishmentSchedule'
+import NumberOfAdditionalDaysRoutes from './punishment_numberOfAdditionalDays'
 import checkPunishmentRoutes from './punishments/checkPunishments'
 import activateSuspendedPunishmentsRoutes from './punishments/activateSuspendedPunishments'
 import suspendedPunishmentScheduleRoutes from './suspendedPunishmentSchedule'
@@ -289,6 +290,10 @@ export default function routes(
   router.use(adjudicationUrls.punishmentComment.root, PunishmentCommentRoutes({ userService, punishmentsService }))
   router.use(adjudicationUrls.punishment.root, PunishmentRoutes({ userService, punishmentsService }))
   router.use(adjudicationUrls.punishmentSchedule.root, PunishmentScheduleRoutes({ userService, punishmentsService }))
+  router.use(
+    adjudicationUrls.numberOfAdditionalDays.root,
+    NumberOfAdditionalDaysRoutes({ userService, punishmentsService })
+  )
 
   router.use(adjudicationUrls.awardPunishments.root, awardPunishmentsRoutes({ punishmentsService, userService }))
   router.use(adjudicationUrls.checkPunishments.root, checkPunishmentRoutes({ punishmentsService, userService }))

--- a/server/routes/punishment/punishmentPage.ts
+++ b/server/routes/punishment/punishmentPage.ts
@@ -111,7 +111,7 @@ export default class PunishmentPage {
         stoppagePercentage: stoppageOfEarningsPercentage,
       })
 
-    const redirectUrlPrefix = this.getRedirectUrl(adjudicationNumber, req)
+    const redirectUrlPrefix = this.getRedirectUrl(adjudicationNumber, req, punishmentType as PunishmentType)
     return res.redirect(
       url.format({
         pathname: redirectUrlPrefix,
@@ -120,7 +120,13 @@ export default class PunishmentPage {
     )
   }
 
-  private getRedirectUrl = (adjudicationNumber: number, req: Request) => {
+  private getRedirectUrl = (adjudicationNumber: number, req: Request, punishmentType: PunishmentType) => {
+    if ([PunishmentType.ADDITIONAL_DAYS, PunishmentType.PROSPECTIVE_DAYS].includes(punishmentType)) {
+      if (this.pageOptions.isEdit()) {
+        return adjudicationUrls.numberOfAdditionalDays.urls.edit(adjudicationNumber, req.params.redisId)
+      }
+      return adjudicationUrls.numberOfAdditionalDays.urls.start(adjudicationNumber)
+    }
     if (this.pageOptions.isEdit()) {
       return adjudicationUrls.punishmentSchedule.urls.edit(adjudicationNumber, req.params.redisId)
     }

--- a/server/routes/punishment_numberOfAdditionalDays/index.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/index.ts
@@ -2,6 +2,7 @@ import express, { RequestHandler, Router } from 'express'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 import NumberOfAdditionalDaysRoute from './numberOfAdditionalDays'
+import NumberOfAdditionalDaysEditRoute from './numberOfAdditionalDaysEdit'
 
 import UserService from '../../services/userService'
 import adjudicationUrls from '../../utils/urlGenerator'
@@ -17,12 +18,15 @@ export default function NumberOfAdditionalDaysRoutes({
   const router = express.Router()
 
   const numberOfAdditionalDaysRoute = new NumberOfAdditionalDaysRoute(userService, punishmentsService)
+  const numberOfAdditionalDaysEditRoute = new NumberOfAdditionalDaysEditRoute(userService, punishmentsService)
 
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
   get(adjudicationUrls.numberOfAdditionalDays.matchers.start, numberOfAdditionalDaysRoute.view)
   post(adjudicationUrls.numberOfAdditionalDays.matchers.start, numberOfAdditionalDaysRoute.submit)
+  get(adjudicationUrls.numberOfAdditionalDays.matchers.edit, numberOfAdditionalDaysEditRoute.view)
+  post(adjudicationUrls.numberOfAdditionalDays.matchers.edit, numberOfAdditionalDaysEditRoute.submit)
 
   return router
 }

--- a/server/routes/punishment_numberOfAdditionalDays/index.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/index.ts
@@ -1,0 +1,28 @@
+import express, { RequestHandler, Router } from 'express'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+import NumberOfAdditionalDaysRoute from './numberOfAdditionalDays'
+
+import UserService from '../../services/userService'
+import adjudicationUrls from '../../utils/urlGenerator'
+import PunishmentsService from '../../services/punishmentsService'
+
+export default function NumberOfAdditionalDaysRoutes({
+  userService,
+  punishmentsService,
+}: {
+  userService: UserService
+  punishmentsService: PunishmentsService
+}): Router {
+  const router = express.Router()
+
+  const numberOfAdditionalDaysRoute = new NumberOfAdditionalDaysRoute(userService, punishmentsService)
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
+
+  get(adjudicationUrls.numberOfAdditionalDays.matchers.start, numberOfAdditionalDaysRoute.view)
+  post(adjudicationUrls.numberOfAdditionalDays.matchers.start, numberOfAdditionalDaysRoute.submit)
+
+  return router
+}

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDays.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDays.test.ts
@@ -4,6 +4,7 @@ import appWithAllRoutes from '../testutils/appSetup'
 import adjudicationUrls from '../../utils/urlGenerator'
 import UserService from '../../services/userService'
 import PunishmentsService from '../../services/punishmentsService'
+import config from '../../config'
 
 jest.mock('../../services/userService')
 jest.mock('../../services/punishmentsService')
@@ -16,6 +17,7 @@ let app: Express
 beforeEach(() => {
   app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
   userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
+  config.addedDaysFlag = 'true'
 })
 
 afterEach(() => {
@@ -38,7 +40,7 @@ describe('GET number of additional days page', () => {
 })
 
 describe('GET number of additional days page', () => {
-  it('should load the `Not proceed` page', () => {
+  it('should load the page', () => {
     return request(app)
       .get(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
       .expect('Content-Type', /html/)
@@ -57,14 +59,14 @@ describe('POST number of additional days page', () => {
         )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=`
       )
       .send({
-        days: 10,
+        numberOfDays: 10,
       })
       .expect(302)
       .expect(
         'Location',
         `${adjudicationUrls.isPunishmentSuspended.urls.start(
           100
-        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&days=10`
+        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&numberOfDays=10`
       )
   })
 })

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDays.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDays.test.ts
@@ -1,0 +1,70 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes from '../testutils/appSetup'
+import adjudicationUrls from '../../utils/urlGenerator'
+import UserService from '../../services/userService'
+import PunishmentsService from '../../services/punishmentsService'
+
+jest.mock('../../services/userService')
+jest.mock('../../services/punishmentsService')
+
+const userService = new UserService(null) as jest.Mocked<UserService>
+const punishmentsService = new PunishmentsService(null) as jest.Mocked<PunishmentsService>
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
+  userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET number of additional days page', () => {
+  beforeEach(() => {
+    app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
+    userService.getUserRoles.mockResolvedValue(['NOT_REVIEWER'])
+  })
+  it('should load the `Page not found` page', () => {
+    return request(app)
+      .get(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Page not found')
+      })
+  })
+})
+
+describe('GET number of additional days page', () => {
+  it('should load the `Not proceed` page', () => {
+    return request(app)
+      .get(adjudicationUrls.numberOfAdditionalDays.urls.start(100))
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Enter the number of additional days')
+      })
+  })
+})
+
+describe('POST number of additional days page', () => {
+  it('should redirect', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.numberOfAdditionalDays.urls.start(
+          100
+        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=`
+      )
+      .send({
+        days: 10,
+      })
+      .expect(302)
+      .expect(
+        'Location',
+        `${adjudicationUrls.isPunishmentSuspended.urls.start(
+          100
+        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&days=10`
+      )
+  })
+})

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDays.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDays.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express'
+import NumberOfAdditionalDaysPage, { PageRequestType } from './numberOfAdditionalDaysPage'
+import UserService from '../../services/userService'
+import PunishmentsService from '../../services/punishmentsService'
+
+export default class numberOfAdditionalDaysRoute {
+  page: NumberOfAdditionalDaysPage
+
+  constructor(private readonly userService: UserService, private readonly punishmentsService: PunishmentsService) {
+    this.page = new NumberOfAdditionalDaysPage(PageRequestType.CREATION, userService, punishmentsService)
+  }
+
+  view = async (req: Request, res: Response): Promise<void> => {
+    await this.page.view(req, res)
+  }
+
+  submit = async (req: Request, res: Response): Promise<void> => {
+    await this.page.submit(req, res)
+  }
+}

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysEdit.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysEdit.test.ts
@@ -1,0 +1,79 @@
+import { Express } from 'express'
+import request from 'supertest'
+import { v4 as uuidv4 } from 'uuid'
+import appWithAllRoutes from '../testutils/appSetup'
+import adjudicationUrls from '../../utils/urlGenerator'
+import UserService from '../../services/userService'
+import PunishmentsService from '../../services/punishmentsService'
+import { PunishmentType } from '../../data/PunishmentResult'
+
+jest.mock('../../services/userService')
+jest.mock('../../services/punishmentsService')
+
+const userService = new UserService(null) as jest.Mocked<UserService>
+const punishmentsService = new PunishmentsService(null) as jest.Mocked<PunishmentsService>
+
+let app: Express
+
+beforeEach(() => {
+  app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
+  userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
+  punishmentsService.getSessionPunishment.mockResolvedValue({
+    type: PunishmentType.ADDITIONAL_DAYS,
+    days: 10,
+    suspendedUntil: '4/4/2023',
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET number of additional days page', () => {
+  beforeEach(() => {
+    app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
+    userService.getUserRoles.mockResolvedValue(['NOT_REVIEWER'])
+  })
+  it('should load the `Page not found` page', () => {
+    return request(app)
+      .get(adjudicationUrls.numberOfAdditionalDays.urls.edit(100, uuidv4()))
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Page not found')
+      })
+  })
+})
+
+describe('GET number of additional days page', () => {
+  it('should load the  page', () => {
+    return request(app)
+      .get(adjudicationUrls.numberOfAdditionalDays.urls.edit(100, uuidv4()))
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Enter the number of additional days')
+      })
+  })
+})
+
+describe('POST number of additional days page', () => {
+  it('should redirect', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.numberOfAdditionalDays.urls.edit(
+          100,
+          'XYZ'
+        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=`
+      )
+      .send({
+        days: 10,
+      })
+      .expect(302)
+      .expect(
+        'Location',
+        `${adjudicationUrls.isPunishmentSuspended.urls.edit(
+          100,
+          'XYZ'
+        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&days=10`
+      )
+  })
+})

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysEdit.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysEdit.test.ts
@@ -6,6 +6,7 @@ import adjudicationUrls from '../../utils/urlGenerator'
 import UserService from '../../services/userService'
 import PunishmentsService from '../../services/punishmentsService'
 import { PunishmentType } from '../../data/PunishmentResult'
+import config from '../../config'
 
 jest.mock('../../services/userService')
 jest.mock('../../services/punishmentsService')
@@ -18,9 +19,10 @@ let app: Express
 beforeEach(() => {
   app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
   userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
+  config.addedDaysFlag = 'true'
   punishmentsService.getSessionPunishment.mockResolvedValue({
     type: PunishmentType.ADDITIONAL_DAYS,
-    days: 10,
+    numberOfDays: 10,
     suspendedUntil: '4/4/2023',
   })
 })
@@ -65,7 +67,7 @@ describe('POST number of additional days page', () => {
         )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=`
       )
       .send({
-        days: 10,
+        numberOfDays: 10,
       })
       .expect(302)
       .expect(
@@ -73,7 +75,7 @@ describe('POST number of additional days page', () => {
         `${adjudicationUrls.isPunishmentSuspended.urls.edit(
           100,
           'XYZ'
-        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&days=10`
+        )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&numberOfDays=10`
       )
   })
 })

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysEdit.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysEdit.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from 'express'
+import NumberOfAdditionalDaysPage, { PageRequestType } from './numberOfAdditionalDaysPage'
+import UserService from '../../services/userService'
+import PunishmentsService from '../../services/punishmentsService'
+
+export default class NumberOfAdditionalDaysEditRoute {
+  page: NumberOfAdditionalDaysPage
+
+  constructor(private readonly userService: UserService, private readonly punishmentsService: PunishmentsService) {
+    this.page = new NumberOfAdditionalDaysPage(PageRequestType.EDIT, userService, punishmentsService)
+  }
+
+  view = async (req: Request, res: Response): Promise<void> => {
+    await this.page.view(req, res)
+  }
+
+  submit = async (req: Request, res: Response): Promise<void> => {
+    await this.page.submit(req, res)
+  }
+}

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysPage.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysPage.ts
@@ -1,0 +1,104 @@
+/* eslint-disable max-classes-per-file */
+import { Request, Response } from 'express'
+import url from 'url'
+import validateForm from './numberOfAdditionalDaysValidation'
+import { FormError } from '../../@types/template'
+import UserService from '../../services/userService'
+import { hasAnyRole } from '../../utils/utils'
+import adjudicationUrls from '../../utils/urlGenerator'
+import PunishmentsService from '../../services/punishmentsService'
+
+type PageData = {
+  error?: FormError
+  days?: number
+}
+
+export enum PageRequestType {
+  CREATION,
+  EDIT,
+}
+
+class PageOptions {
+  constructor(private readonly pageType: PageRequestType) {}
+
+  isEdit(): boolean {
+    return this.pageType === PageRequestType.EDIT
+  }
+}
+
+export default class PunishmentSchedulePage {
+  pageOptions: PageOptions
+
+  constructor(
+    pageType: PageRequestType,
+    private readonly userService: UserService,
+    private readonly punishmentsService: PunishmentsService
+  ) {
+    this.pageOptions = new PageOptions(pageType)
+  }
+
+  private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
+    const adjudicationNumber = Number(req.params.adjudicationNumber)
+    const { error, days } = pageData
+
+    return res.render(`pages/numberOfAdditionalDays.njk`, {
+      cancelHref: adjudicationUrls.awardPunishments.urls.modified(adjudicationNumber),
+      errors: error ? [error] : [],
+      days,
+    })
+  }
+
+  view = async (req: Request, res: Response): Promise<void> => {
+    const adjudicationNumber = Number(req.params.adjudicationNumber)
+    const userRoles = await this.userService.getUserRoles(res.locals.user.token)
+
+    if (!hasAnyRole(['ADJUDICATIONS_REVIEWER'], userRoles)) {
+      return res.render('pages/notFound.njk', { url: req.headers.referer || adjudicationUrls.homepage.root })
+    }
+
+    if (this.pageOptions.isEdit()) {
+      const sessionData = await this.punishmentsService.getSessionPunishment(
+        req,
+        adjudicationNumber,
+        req.params.redisId
+      )
+      return this.renderView(req, res, {
+        days: sessionData.days,
+      })
+    }
+
+    return this.renderView(req, res, {})
+  }
+
+  submit = async (req: Request, res: Response): Promise<void> => {
+    const adjudicationNumber = Number(req.params.adjudicationNumber)
+    const { days } = req.body
+
+    const trimmedDays = days ? Number(String(days).trim()) : null
+
+    const error = validateForm({
+      days: trimmedDays,
+    })
+
+    if (error)
+      return this.renderView(req, res, {
+        error,
+        days: trimmedDays,
+      })
+
+    const redirectUrlPrefix = this.getRedirectUrl(adjudicationNumber, req)
+    return res.redirect(
+      url.format({
+        pathname: redirectUrlPrefix,
+        query: { ...req.query, days: trimmedDays },
+      })
+    )
+  }
+
+  private getRedirectUrl = (adjudicationNumber: number, req: Request) => {
+    if (this.pageOptions.isEdit()) {
+      return adjudicationUrls.isPunishmentSuspended.urls.edit(adjudicationNumber, req.params.redisId)
+    }
+    return adjudicationUrls.isPunishmentSuspended.urls.start(adjudicationNumber)
+  }
+}

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysPage.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysPage.ts
@@ -10,7 +10,7 @@ import PunishmentsService from '../../services/punishmentsService'
 
 type PageData = {
   error?: FormError
-  days?: number
+  numberOfDays?: number
 }
 
 export enum PageRequestType {
@@ -39,12 +39,12 @@ export default class PunishmentSchedulePage {
 
   private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
     const adjudicationNumber = Number(req.params.adjudicationNumber)
-    const { error, days } = pageData
+    const { error, numberOfDays } = pageData
 
     return res.render(`pages/numberOfAdditionalDays.njk`, {
       cancelHref: adjudicationUrls.awardPunishments.urls.modified(adjudicationNumber),
       errors: error ? [error] : [],
-      days,
+      numberOfDays,
     })
   }
 
@@ -63,7 +63,7 @@ export default class PunishmentSchedulePage {
         req.params.redisId
       )
       return this.renderView(req, res, {
-        days: sessionData.days,
+        numberOfDays: sessionData.numberOfDays,
       })
     }
 
@@ -72,25 +72,25 @@ export default class PunishmentSchedulePage {
 
   submit = async (req: Request, res: Response): Promise<void> => {
     const adjudicationNumber = Number(req.params.adjudicationNumber)
-    const { days } = req.body
+    const { numberOfDays } = req.body
 
-    const trimmedDays = days ? Number(String(days).trim()) : null
+    const trimmedDays = numberOfDays ? Number(String(numberOfDays).trim()) : null
 
     const error = validateForm({
-      days: trimmedDays,
+      numberOfDays: trimmedDays,
     })
 
     if (error)
       return this.renderView(req, res, {
         error,
-        days: trimmedDays,
+        numberOfDays: trimmedDays,
       })
 
     const redirectUrlPrefix = this.getRedirectUrl(adjudicationNumber, req)
     return res.redirect(
       url.format({
         pathname: redirectUrlPrefix,
-        query: { ...req.query, days: trimmedDays },
+        query: { ...req.query, numberOfDays: trimmedDays },
       })
     )
   }

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.test.ts
@@ -4,17 +4,17 @@ describe('validateForm', () => {
   it('Valid submit when days correct', () => {
     expect(
       validateForm({
-        days: 10,
+        numberOfDays: 10,
       })
     ).toBeNull()
   })
   it('shows error when no days entered', () => {
     expect(
       validateForm({
-        days: null,
+        numberOfDays: null,
       })
     ).toEqual({
-      href: '#days',
+      href: '#numberOfDays',
       text: 'Enter how many days the punishment will last',
     })
   })
@@ -22,20 +22,20 @@ describe('validateForm', () => {
     expect(
       validateForm({
         // @ts-expect-error: Ignore typecheck here
-        days: 'hello',
+        numberOfDays: 'hello',
       })
     ).toEqual({
-      href: '#days',
+      href: '#numberOfDays',
       text: 'Enter a number of days',
     })
   })
   it('shows error when too few days are entered', () => {
     expect(
       validateForm({
-        days: 0,
+        numberOfDays: 0,
       })
     ).toEqual({
-      href: '#days',
+      href: '#numberOfDays',
       text: 'Enter one or more days',
     })
   })

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.test.ts
@@ -1,22 +1,14 @@
 import validateForm from './numberOfAdditionalDaysValidation'
 
 describe('validateForm', () => {
-  it('Valid submit when prospective days', () => {
+  it('Valid submit when days correct', () => {
     expect(
       validateForm({
         days: 10,
       })
     ).toBeNull()
   })
-
-  it('Valid submit when additional days', () => {
-    expect(
-      validateForm({
-        days: 10,
-      })
-    ).toBeNull()
-  })
-  it('shows error when no days select', () => {
+  it('shows error when no days entered', () => {
     expect(
       validateForm({
         days: null,
@@ -24,6 +16,17 @@ describe('validateForm', () => {
     ).toEqual({
       href: '#days',
       text: 'Enter how many days the punishment will last',
+    })
+  })
+  it('shows error when something other than a number is entered', () => {
+    expect(
+      validateForm({
+        // @ts-expect-error: Ignore typecheck here
+        days: 'hello',
+      })
+    ).toEqual({
+      href: '#days',
+      text: 'Enter a number of days',
     })
   })
   it('shows error when too few days are entered', () => {

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.test.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.test.ts
@@ -1,0 +1,39 @@
+import validateForm from './numberOfAdditionalDaysValidation'
+
+describe('validateForm', () => {
+  it('Valid submit when prospective days', () => {
+    expect(
+      validateForm({
+        days: 10,
+      })
+    ).toBeNull()
+  })
+
+  it('Valid submit when additional days', () => {
+    expect(
+      validateForm({
+        days: 10,
+      })
+    ).toBeNull()
+  })
+  it('shows error when no days select', () => {
+    expect(
+      validateForm({
+        days: null,
+      })
+    ).toEqual({
+      href: '#days',
+      text: 'Enter how many days the punishment will last',
+    })
+  })
+  it('shows error when too few days are entered', () => {
+    expect(
+      validateForm({
+        days: 0,
+      })
+    ).toEqual({
+      href: '#days',
+      text: 'Enter one or more days',
+    })
+  })
+})

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.ts
@@ -1,27 +1,27 @@
 import { FormError } from '../../@types/template'
 
 type NumberOfAddedDaysForm = {
-  days: number
+  numberOfDays: number
 }
 
 const errors: { [key: string]: FormError } = {
-  MISSING_DAYS: {
-    href: '#days',
-    text: 'Enter how many days the punishment will last',
+  NOT_NUMERICAL: {
+    href: '#numberOfDays',
+    text: 'Enter a number of days',
   },
   DAYS_TOO_FEW: {
-    href: '#days',
+    href: '#numberOfDays',
     text: 'Enter one or more days',
   },
-  NOT_NUMERICAL: {
-    href: '#days',
-    text: 'Enter a number of days',
+  MISSING_DAYS: {
+    href: '#numberOfDays',
+    text: 'Enter how many days the punishment will last',
   },
 }
 
-export default function validateForm({ days }: NumberOfAddedDaysForm): FormError | null {
-  if (Number.isNaN(days) || typeof days === 'string') return errors.NOT_NUMERICAL
-  if (Number.isInteger(days) && days <= 0) return errors.DAYS_TOO_FEW
-  if (days === undefined || days === null || !days) return errors.MISSING_DAYS
+export default function validateForm({ numberOfDays }: NumberOfAddedDaysForm): FormError | null {
+  if (Number.isNaN(numberOfDays) || typeof numberOfDays === 'string') return errors.NOT_NUMERICAL
+  if (Number.isInteger(numberOfDays) && numberOfDays <= 0) return errors.DAYS_TOO_FEW
+  if (numberOfDays === undefined || numberOfDays === null || !numberOfDays) return errors.MISSING_DAYS
   return null
 }

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.ts
@@ -1,0 +1,22 @@
+import { FormError } from '../../@types/template'
+
+type NumberOfAddedDaysForm = {
+  days: number
+}
+
+const errors: { [key: string]: FormError } = {
+  MISSING_DAYS: {
+    href: '#days',
+    text: 'Enter how many days the punishment will last',
+  },
+  DAYS_TOO_FEW: {
+    href: '#days',
+    text: 'Enter one or more days',
+  },
+}
+
+export default function validateForm({ days }: NumberOfAddedDaysForm): FormError | null {
+  if (Number.isInteger(days) && days <= 0) return errors.DAYS_TOO_FEW
+  if (days === undefined || days === null || !days) return errors.MISSING_DAYS
+  return null
+}

--- a/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.ts
+++ b/server/routes/punishment_numberOfAdditionalDays/numberOfAdditionalDaysValidation.ts
@@ -13,9 +13,14 @@ const errors: { [key: string]: FormError } = {
     href: '#days',
     text: 'Enter one or more days',
   },
+  NOT_NUMERICAL: {
+    href: '#days',
+    text: 'Enter a number of days',
+  },
 }
 
 export default function validateForm({ days }: NumberOfAddedDaysForm): FormError | null {
+  if (Number.isNaN(days) || typeof days === 'string') return errors.NOT_NUMERICAL
   if (Number.isInteger(days) && days <= 0) return errors.DAYS_TOO_FEW
   if (days === undefined || days === null || !days) return errors.MISSING_DAYS
   return null

--- a/server/services/reportedAdjudicationsService.test.ts
+++ b/server/services/reportedAdjudicationsService.test.ts
@@ -796,7 +796,7 @@ describe('reportedAdjudicationsService', () => {
       ])
     })
   })
-  describe.only('getOutcomesHistory', () => {
+  describe('getOutcomesHistory', () => {
     it('returns empty array if there is no history present', async () => {
       const result = await service.getOutcomesHistory([], user)
       expect(result).toEqual([])

--- a/server/utils/urlGenerator.ts
+++ b/server/utils/urlGenerator.ts
@@ -646,6 +646,30 @@ const adjudicationUrls = {
         `${adjudicationUrls.punishmentSchedule.root}/${adjudicationNumber}/edit/${redisId}`,
     },
   },
+  numberOfAdditionalDays: {
+    root: '/number-additional-days',
+    matchers: {
+      start: '/:adjudicationNumber',
+      edit: '/:adjudicationNumber/edit/:redisId',
+    },
+    urls: {
+      start: (adjudicationNumber: number) => `${adjudicationUrls.numberOfAdditionalDays.root}/${adjudicationNumber}`,
+      edit: (adjudicationNumber: number, redisId: string) =>
+        `${adjudicationUrls.numberOfAdditionalDays.root}/${adjudicationNumber}/edit/${redisId}`,
+    },
+  },
+  isPunishmentSuspended: {
+    root: '/punishment-suspended',
+    matchers: {
+      start: '/:adjudicationNumber',
+      edit: '/:adjudicationNumber/edit/:redisId',
+    },
+    urls: {
+      start: (adjudicationNumber: number) => `${adjudicationUrls.isPunishmentSuspended.root}/${adjudicationNumber}`,
+      edit: (adjudicationNumber: number, redisId: string) =>
+        `${adjudicationUrls.isPunishmentSuspended.root}/${adjudicationNumber}/edit/${redisId}`,
+    },
+  },
   awardPunishments: {
     root: '/award-punishments',
     matchers: {

--- a/server/views/pages/numberOfAdditionalDays.njk
+++ b/server/views/pages/numberOfAdditionalDays.njk
@@ -27,11 +27,11 @@
       <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
       {{ govukInput({
-        id: "days",
-        name: "days",
-        value: days,
+        id: "numberOfDays",
+        name: "numberOfDays",
+        value: numberOfDays,
         classes: "govuk-input--width-5",
-        errorMessage: errors | findErrors(["days"])
+        errorMessage: errors | findErrors(["numberOfDays"])
       }) }}
 
       <div class="govuk-button-group">

--- a/server/views/pages/numberOfAdditionalDays.njk
+++ b/server/views/pages/numberOfAdditionalDays.njk
@@ -40,9 +40,9 @@
           type: "submit",
           preventDoubleClick: true,
           classes: "govuk-button--submit govuk-!-margin-right-3",
-          attributes: { "data-qa": "punishment-schedule-submit" }
+          attributes: { "data-qa": "submit" }
         }) }}
-        <a class="govuk-link" href=' {{ cancelHref }} ' data-qa='punishment-schedule-cancel'>Return to 'Award Punishments'</a>
+        <a class="govuk-link" href=' {{ cancelHref }} ' data-qa='cancel'>Return to 'Award Punishments'</a>
       </div>
 
     </form>

--- a/server/views/pages/numberOfAdditionalDays.njk
+++ b/server/views/pages/numberOfAdditionalDays.njk
@@ -1,0 +1,50 @@
+{% extends "../partials/layout.njk" %}
+{% from "../partials/breadCrumb.njk" import breadcrumb %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+
+{% set title = "Enter the number of additional days" %}
+
+{% block pageTitle %}
+  {{ title }}
+{% endblock %}
+{% block beforeContent %}
+  {{ breadcrumb() }}
+{% endblock %}
+
+{% block content %}
+  {% if errors | length %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors,
+      attributes: { "data-qa": "error-summary" }
+    }) }}
+  {% endif %}
+  <h1 class="govuk-heading-l">{{ title }}</h1>
+  <div>
+    <form method="POST" novalidate="novalidate" class="govuk-!-margin-top-5">
+      <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+      {{ govukInput({
+        id: "days",
+        name: "days",
+        value: days,
+        classes: "govuk-input--width-5",
+        errorMessage: errors | findErrors(["days"])
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: 'Continue',
+          type: "submit",
+          preventDoubleClick: true,
+          classes: "govuk-button--submit govuk-!-margin-right-3",
+          attributes: { "data-qa": "punishment-schedule-submit" }
+        }) }}
+        <a class="govuk-link" href=' {{ cancelHref }} ' data-qa='punishment-schedule-cancel'>Return to 'Award Punishments'</a>
+      </div>
+
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
New page & edit version - number of additional days
This page is reached when a user selects the additional days or prospective additional days radio button options on the 'add a punishment' flow. It passes the query items from the first page through, as well as the number of days entered here, through to the next page (new -"is this punishment be suspended?")
One int test skipped until the rest of this flow is completed.