### PR TITLE
NN-5373: Change data tile and refactor

### DIFF
--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -44,7 +44,6 @@
       {% endif %}
     </div>
 
-
       <div class="govuk-grid-row">
         <ul class="card-group govuk-!-margin-bottom-0">
           {% for task in reviewerTasks %}
@@ -78,6 +77,25 @@
                 }) }}
             </li>
           {% endfor %}
+        </ul>
+        {% if disRelatedTasks.length %}
+          <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-7 govuk-!-margin-top-2" data-qa="section-break">
+        {% endif %}
+      </div>
+
+      <div class="govuk-grid-row">
+        <ul class="card-group">
+          <li class="govuk-grid-column-one-third card-group__item">
+            {% if dataInsightsTask.enabled %}
+              {{ card({
+                  "href": dataInsightsTask.href,
+                  "clickable": "true",
+                  "heading": dataInsightsTask.heading,
+                  "description": dataInsightsTask.description,
+                  "id": dataInsightsTask.id
+                }) }}
+                {% endif %}
+            </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Insights tile separated as it doesn't need to be included with the other role-based tiles.

For context on the other change - I looked back at the history of this file and the reason that the 'enter outcomes' tile was separated was because it was originally wrapped in a flag prior to release. When that flag was removed, the tile data wasn't moved into the array with the other tile data like it should have been!