### PR TITLE
NN-5289: fix by treating the flow as a create, rather than an edit

### DIFF
--- a/integration_tests/integration/manuallyActivateSuspendedPunishment.cy.ts
+++ b/integration_tests/integration/manuallyActivateSuspendedPunishment.cy.ts
@@ -283,7 +283,7 @@ context('Manually activate an existing suspended punishment', () => {
         punishmentPage.submitButton().click()
 
         cy.location().should(loc => {
-          expect(loc.pathname).to.eq(adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(101, undefined))
+          expect(loc.pathname).to.eq(adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(101))
           expect(loc.search).to.eq(
             `?punishmentType=${punishmentType}&privilegeType=&otherPrivilege=&stoppagePercentage=&reportNo=123456`
           )

--- a/server/routes/additionalDays/numberOfAdditionalDays/numberOfAdditionalDaysManualEdit.test.ts
+++ b/server/routes/additionalDays/numberOfAdditionalDays/numberOfAdditionalDaysManualEdit.test.ts
@@ -1,6 +1,5 @@
 import { Express } from 'express'
 import request from 'supertest'
-import { v4 as uuidv4 } from 'uuid'
 import appWithAllRoutes from '../../testutils/appSetup'
 import adjudicationUrls from '../../../utils/urlGenerator'
 import UserService from '../../../services/userService'

--- a/server/routes/additionalDays/numberOfAdditionalDays/numberOfAdditionalDaysManualEdit.test.ts
+++ b/server/routes/additionalDays/numberOfAdditionalDays/numberOfAdditionalDaysManualEdit.test.ts
@@ -38,7 +38,7 @@ describe('GET number of additional days page', () => {
   })
   it('should load the `Page not found` page', () => {
     return request(app)
-      .get(adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(100, uuidv4()))
+      .get(adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(100))
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Page not found')
@@ -49,7 +49,7 @@ describe('GET number of additional days page', () => {
 describe('GET number of additional days page', () => {
   it('should load the  page', () => {
     return request(app)
-      .get(adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(100, uuidv4()))
+      .get(adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(100))
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Enter the number of additional days')
@@ -62,8 +62,7 @@ describe('POST number of additional days page', () => {
     return request(app)
       .post(
         `${adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(
-          100,
-          'XYZ'
+          100
         )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=`
       )
       .send({
@@ -72,9 +71,8 @@ describe('POST number of additional days page', () => {
       .expect(302)
       .expect(
         'Location',
-        `${adjudicationUrls.whichPunishmentIsItConsecutiveToManual.urls.edit(
-          100,
-          'XYZ'
+        `${adjudicationUrls.whichPunishmentIsItConsecutiveToManual.urls.start(
+          100
         )}?punishmentType=ADDITIONAL_DAYS&privilegeType=&otherPrivilege=&stoppagePercentage=&days=10`
       )
   })

--- a/server/routes/additionalDays/numberOfAdditionalDays/numberOfAdditionalDaysPage.ts
+++ b/server/routes/additionalDays/numberOfAdditionalDays/numberOfAdditionalDaysPage.ts
@@ -106,7 +106,7 @@ export default class NumberOfAdditionalDaysPage {
       return adjudicationUrls.isPunishmentSuspended.urls.edit(adjudicationNumber, req.params.redisId)
     }
     if (this.pageOptions.isManualEdit()) {
-      return adjudicationUrls.whichPunishmentIsItConsecutiveToManual.urls.edit(adjudicationNumber, req.params.redisId)
+      return adjudicationUrls.whichPunishmentIsItConsecutiveToManual.urls.start(adjudicationNumber)
     }
     return adjudicationUrls.isPunishmentSuspended.urls.start(adjudicationNumber)
   }

--- a/server/routes/punishments/manuallyActivateSuspendedPunishments/manuallyActivateSuspendedPunishments.test.ts
+++ b/server/routes/punishments/manuallyActivateSuspendedPunishments/manuallyActivateSuspendedPunishments.test.ts
@@ -80,8 +80,7 @@ describe('POST', () => {
         .expect(
           'Location',
           `${adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(
-            100,
-            undefined
+            100
           )}?punishmentType=${punishmentType}&privilegeType=&otherPrivilege=&stoppagePercentage=&reportNo=123456`
         )
     }

--- a/server/routes/punishments/manuallyActivateSuspendedPunishments/manuallyActivateSuspendedPunishmentsPage.ts
+++ b/server/routes/punishments/manuallyActivateSuspendedPunishments/manuallyActivateSuspendedPunishmentsPage.ts
@@ -84,7 +84,7 @@ export default class ManuallyActivateSuspendedPunishmentsPage {
 
   private getRedirectUrl = (adjudicationNumber: number, req: Request, punishmentType: PunishmentType) => {
     if ([PunishmentType.ADDITIONAL_DAYS, PunishmentType.PROSPECTIVE_DAYS].includes(punishmentType)) {
-      return adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(adjudicationNumber, req.params.redisId)
+      return adjudicationUrls.numberOfAdditionalDays.urls.manualEdit(adjudicationNumber)
     }
     return adjudicationUrls.suspendedPunishmentSchedule.urls.manual(adjudicationNumber)
   }

--- a/server/utils/urlGenerator.ts
+++ b/server/utils/urlGenerator.ts
@@ -651,14 +651,14 @@ const adjudicationUrls = {
     matchers: {
       start: '/:adjudicationNumber',
       edit: '/:adjudicationNumber/edit/:redisId',
-      manualEdit: '/:adjudicationNumber/manualEdit/:redisId',
+      manualEdit: '/:adjudicationNumber/manualEdit/',
     },
     urls: {
       start: (adjudicationNumber: number) => `${adjudicationUrls.numberOfAdditionalDays.root}/${adjudicationNumber}`,
       edit: (adjudicationNumber: number, redisId: string) =>
         `${adjudicationUrls.numberOfAdditionalDays.root}/${adjudicationNumber}/edit/${redisId}`,
-      manualEdit: (adjudicationNumber: number, redisId: string) =>
-        `${adjudicationUrls.numberOfAdditionalDays.root}/${adjudicationNumber}/manualEdit/${redisId}`,
+      manualEdit: (adjudicationNumber: number) =>
+        `${adjudicationUrls.numberOfAdditionalDays.root}/${adjudicationNumber}/manualEdit`,
     },
   },
   isPunishmentSuspended: {


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/NN-5289

`manualEdit/redisId` was `undefined` because we're not updating an existing punishment