### PR TITLE
NN-5545: update which API client we use for getHearingsGivenAgencyAndDate

### DIFF
--- a/server/data/manageAdjudicationsSystemTokensClient.ts
+++ b/server/data/manageAdjudicationsSystemTokensClient.ts
@@ -23,6 +23,7 @@ import {
   allIssueStatuses,
   ReportedAdjudicationFilter,
   allStatuses,
+  ScheduledHearingList,
 } from './ReportedAdjudicationResult'
 import { ApiPageRequest, ApiPageResponse } from './ApiData'
 import RestClient from './restClient'
@@ -318,6 +319,12 @@ export default class ManageAdjudicationsSystemTokensClient {
   async getAgencyReportCounts(): Promise<AgencyReportCounts> {
     return this.restClient.get({
       path: `/reported-adjudications/report-counts`,
+    })
+  }
+
+  async getHearingsGivenAgencyAndDate(chosenHearingDate: string): Promise<ScheduledHearingList> {
+    return this.restClient.get({
+      path: `/reported-adjudications/hearings?hearingDate=${chosenHearingDate}`,
     })
   }
 }

--- a/server/data/manageAdjudicationsUserTokensClient.ts
+++ b/server/data/manageAdjudicationsUserTokensClient.ts
@@ -3,7 +3,6 @@ import { OffenceDetails } from './DraftAdjudicationResult'
 import {
   ReportedAdjudicationResult,
   ReportedAdjudication,
-  ScheduledHearingList,
   ReportedAdjudicationStatus,
   ReportedAdjudicationFilter,
   allStatuses,
@@ -156,12 +155,6 @@ export default class ManageAdjudicationsUserTokensClient {
     return this.restClient.put({
       path: `/reported-adjudications/${chargeNumber}/hearing/v2`,
       data: hearingDetails,
-    })
-  }
-
-  async getHearingsGivenAgencyAndDate(chosenHearingDate: string): Promise<ScheduledHearingList> {
-    return this.restClient.get({
-      path: `/reported-adjudications/hearings?hearingDate=${chosenHearingDate}`,
     })
   }
 

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -686,7 +686,10 @@ export default class ReportedAdjudicationsService {
   }
 
   async getAllHearings(chosenHearingDate: string, user: User) {
-    const results = await new ManageAdjudicationsUserTokensClient(user).getHearingsGivenAgencyAndDate(chosenHearingDate)
+    const token = await this.hmppsAuthClient.getSystemClientToken(user.username)
+    const results = await new ManageAdjudicationsSystemTokensClient(token, user).getHearingsGivenAgencyAndDate(
+      chosenHearingDate
+    )
 
     const { hearings } = results
 


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/NN-5545

Required on the back of https://github.com/ministryofjustice/hmpps-manage-adjudications-api/pull/533