### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.1.0
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.3
 
 parameters:
@@ -69,7 +69,8 @@ jobs:
       - run:
           command: |
             npm run build
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:
@@ -124,7 +125,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: integration tests
-          command:  |
+          command: |
             TESTFILES=$(circleci tests glob "integration_tests/integration/*.cy.ts" | circleci tests split | paste -sd ',')
             npm run int-test -- --spec ${TESTFILES}
       - store_test_results:

--- a/helm_deploy/hmpps-manage-adjudications/Chart.yaml
+++ b/helm_deploy/hmpps-manage-adjudications/Chart.yaml
@@ -5,12 +5,12 @@ name: hmpps-manage-adjudications
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.6.5
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: 2.6.5
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-manage-adjudications/values.yaml
+++ b/helm_deploy/hmpps-manage-adjudications/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-manage-adjudications
   productId: "DPS001"
@@ -7,14 +6,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-manage-adjudications
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-manage-adjudications-cert
- 
+
   livenessProbe:
     httpGet:
       path: /ping
@@ -50,13 +49,8 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    global-protect: "35.176.93.186/32"
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: hmpps-manage-adjudications
@@ -70,8 +64,14 @@ gotenberg:
     tag: 7.9.1
     port: 3000
 
-  containerCommand: ["gotenberg"]
-  containerArgs: ["--chromium-ignore-certificate-errors","--api-timeout=30s","--pdfengines-engines=pdftk","--uno-listener-restart-threshold=0"]
+  containerCommand: [ "gotenberg" ]
+  containerArgs:
+    [
+      "--chromium-ignore-certificate-errors",
+      "--api-timeout=30s",
+      "--pdfengines-engines=pdftk",
+      "--uno-listener-restart-threshold=0"
+    ]
 
   ingress:
     enabled: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-manage-adjudications/values.yaml
 
 generic-service:
@@ -26,53 +25,10 @@ generic-service:
     ENVIRONMENT_NAME: 'PRE-PRODUCTION'
 
   allowlist:
-    global-protect: "35.176.93.186/32"
-    office: "217.33.148.210/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    health-kick: "35.177.252.195/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    mojvpn: "81.134.202.29/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    durham-tees-valley: "51.179.197.1/32"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    sodexo4: "51.148.9.201"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webprox23: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    crc-rrp: "62.253.83.37/32"
-    crc-pp-wwm: "5.153.255.210/32"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
+    groups:
+      - internal
+      - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-manage-adjudications/values.yaml
 
 generic-service:
@@ -24,53 +23,10 @@ generic-service:
     MAINTENANCE_MODE: false
 
   allowlist:
-    global-protect: "35.176.93.186/32"
-    office: "217.33.148.210/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    health-kick: "35.177.252.195/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    mojvpn: "81.134.202.29/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    durham-tees-valley: "51.179.197.1/32"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    sodexo4: "51.148.9.201"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webprox23: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    crc-rrp: "62.253.83.37/32"
-    crc-pp-wwm: "5.153.255.210/32"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
+    groups:
+      - internal
+      - prisons
+      - private_prisons
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

3 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-manage-adjudications/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `7 => 0 (7 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `47 => 0 (47 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- quantum
  

- quantum_alt
  

- health-kick
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- durham-tees-valley
  

- interservfls
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

- crc-rrp
  

- crc-pp-wwm
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `47 => 0 (47 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- quantum
  

- quantum_alt
  

- health-kick
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- durham-tees-valley
  

- interservfls
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

- crc-rrp
  

- crc-pp-wwm
  
