### PR TITLE
MAP-1932 use correct endpoint to get nomis mapping data

### DIFF
--- a/integration_tests/mockApis/nomisSyncPrisonerMappingApi.ts
+++ b/integration_tests/mockApis/nomisSyncPrisonerMappingApi.ts
@@ -25,7 +25,7 @@ const stubGetDpsLocationId = ({
   stubFor({
     request: {
       method: 'GET',
-      url: `/nomisSyncPrisonerMappingApi/mapping/locations/nomis/${nomisLocationId}`,
+      url: `/nomisSyncPrisonerMappingApi/api/locations/nomis/${nomisLocationId}`,
     },
     response: {
       status: 200,

--- a/integration_tests/mockApis/nomisSyncPrisonerMappingApi.ts
+++ b/integration_tests/mockApis/nomisSyncPrisonerMappingApi.ts
@@ -44,7 +44,7 @@ const stubGetNomisLocationId = ({
   stubFor({
     request: {
       method: 'GET',
-      url: `/nomisSyncPrisonerMappingApi/mapping/locations/dps/${dpsLocationId}`,
+      url: `/nomisSyncPrisonerMappingApi/api/locations/dps/${dpsLocationId}`,
     },
     response: {
       status: 200,

--- a/server/data/nomisSyncPrisonerMappingApiClient.ts
+++ b/server/data/nomisSyncPrisonerMappingApiClient.ts
@@ -11,13 +11,13 @@ export default class NomisSyncPrisonerMappingApiClient {
 
   async getDpsLocationId(nomisLocationId: number): Promise<NomisSyncMapLocation> {
     return this.restClient.get({
-      path: `/mapping/locations/nomis/${nomisLocationId}`,
+      path: `/api/locations/nomis/${nomisLocationId}`,
     })
   }
 
   async getNomisLocationId(dpsLocationId: string): Promise<NomisSyncMapLocation> {
     return this.restClient.get({
-      path: `/mapping/locations/dps/${dpsLocationId}`,
+      path: `/api/locations/dps/${dpsLocationId}`,
     })
   }
 }


### PR DESCRIPTION
previously used incorrect endpoint. Both old and new return same data.
New endpoint requires NOMIS_DPS_MAPPING__LOCATIONS__R role which is being requested. 

will not merge until new role in place for all 3 environments