### PR TITLE
NN-6020 - PDF Rendering Issue

### DIFF
--- a/helm_deploy/hmpps-manage-adjudications/values.yaml
+++ b/helm_deploy/hmpps-manage-adjudications/values.yaml
@@ -68,8 +68,10 @@ gotenberg:
   containerArgs:
     [
       "--chromium-ignore-certificate-errors",
-      "--api-timeout=30s",
-      "--pdfengines-engines=pdftk",
+      "--pdfengines-merge-engines=pdftk",
+      "--libreoffice-disable-routes",
+      "--webhook-disable",
+      "--prometheus-disable-collect"
     ]
 
   ingress:

--- a/server/data/gotenbergClient.ts
+++ b/server/data/gotenbergClient.ts
@@ -26,8 +26,8 @@ export default class GotenbergClient {
       .set('Content-Type', 'multi-part/form-data')
       .buffer(true)
       .attach('files', Buffer.from(html), 'index.html')
-      .attach('files', Buffer.from(headerHtml), 'header.html')
-      .attach('files', Buffer.from(footerHtml), 'footer.html')
+      .attach('files2', Buffer.from(headerHtml), 'header.html')
+      .attach('files3', Buffer.from(footerHtml), 'footer.html')
       .responseType('blob')
 
     // Gotenberg defaults to using A4 format. Page size and margins specified in inches


### PR DESCRIPTION
Replaced deprecated containerArgs

From https://gotenberg.dev/docs/configuration#pdf-engines
As of Gotenberg 8.13.0, the flag --pdfengines-engines has been deprecated.

Updated gotenbergClient as per:
https://github.com/ministryofjustice/hmpps-historical-prisoner/blob/main/server/data/gotenbergClient.ts