### PR TITLE
MAP-2119: Adding UUID parameter for calls to adjudications API

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
         stubGetLocations: locationsInsidePrisonApi.stubGetLocations,
         stubGetAdjudicationLocations: locationsInsidePrisonApi.stubGetAdjudicationLocations,
         stubGetLocation: locationsInsidePrisonApi.stubGetLocation,
+        stubGetLocationWithUuid: locationsInsidePrisonApi.stubGetLocationWithUuid,
         stubGetDpsLocationId: nomisSyncPrisonerMappingApi.stubGetDpsLocationId,
         stubGetNomisLocationId: nomisSyncPrisonerMappingApi.stubGetNomisLocationId,
         stubGetAgency: prisonApi.stubGetAgency,

--- a/integration_tests/integration/scheduleHearingEdit.cy.ts
+++ b/integration_tests/integration/scheduleHearingEdit.cy.ts
@@ -67,7 +67,7 @@ context('Schedule a hearing page', () => {
       response: testData.residentialLocationsFromLocationsApi(),
     })
 
-    cy.task('stubGetLocation', {})
+    cy.task('stubGetLocationWithUuid', {})
 
     cy.task('stubGetLocation', {
       locationId: 'location-2',

--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -16,6 +16,30 @@ const stubPing = (status = 200): SuperAgentRequest =>
   })
 
 const stubGetLocation = ({
+  locationId = 'location-1',
+  response = {
+    id: 'location-1',
+    prisonId: 'MDI',
+    key: 'MDI-1',
+    localName: 'Houseblock 1',
+  },
+}: {
+  locationId: string
+  response: LocationsApiLocation
+}): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: `/locationsInsidePrisonApi/locations/${locationId}?formatLocalName=true`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: response,
+    },
+  })
+
+const stubGetLocationWithUuid = ({
   locationId = '0194ac90-2def-7c63-9f46-b3ccc911fdff',
   response = {
     id: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
@@ -80,6 +104,7 @@ const stubGetAdjudicationLocations = ({
 export default {
   stubPing,
   stubGetLocation,
+  stubGetLocationWithUuid,
   stubGetLocations,
   stubGetAdjudicationLocations,
 }

--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -16,9 +16,9 @@ const stubPing = (status = 200): SuperAgentRequest =>
   })
 
 const stubGetLocation = ({
-  locationId = 'location-1',
+  locationId = '0194ac90-2def-7c63-9f46-b3ccc911fdff',
   response = {
-    id: 'location-1',
+    id: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
     prisonId: 'MDI',
     key: 'MDI-1',
     localName: 'Houseblock 1',

--- a/server/data/DraftAdjudicationResult.ts
+++ b/server/data/DraftAdjudicationResult.ts
@@ -1,7 +1,7 @@
 import { ProtectedCharacteristicsTypes } from '../routes/offenceCodeDecisions/offenceData'
 
 export type IncidentDetails = {
-  locationId: number
+  locationId: number // TODO: MAP-2114: remove at a later date
   locationUuid: string
   dateTimeOfIncident: string
   handoverDeadline?: string
@@ -85,7 +85,7 @@ type SummarySectionItems = {
 
 export type EditedIncidentDetails = {
   dateTimeOfIncident: string
-  locationId: number
+  locationId: number // TODO: MAP-2114: remove at a later date
   locationUuid: string
   incidentRole?: IncidentRole
   removeExistingOffences?: boolean

--- a/server/data/DraftAdjudicationResult.ts
+++ b/server/data/DraftAdjudicationResult.ts
@@ -2,6 +2,7 @@ import { ProtectedCharacteristicsTypes } from '../routes/offenceCodeDecisions/of
 
 export type IncidentDetails = {
   locationId: number
+  locationUuid: string
   dateTimeOfIncident: string
   handoverDeadline?: string
   discoveryRadioSelected?: string
@@ -85,6 +86,7 @@ type SummarySectionItems = {
 export type EditedIncidentDetails = {
   dateTimeOfIncident: string
   locationId: number
+  locationUuid: string
   incidentRole?: IncidentRole
   removeExistingOffences?: boolean
 }

--- a/server/data/HearingAndOutcomeResult.ts
+++ b/server/data/HearingAndOutcomeResult.ts
@@ -93,7 +93,7 @@ export enum ReferGovReason {
 
 export type HearingDetails = {
   id?: number
-  locationId: number
+  locationId: number // TODO: MAP-2114: remove at a later date
   locationUuid: string
   dateTimeOfHearing: string
   oicHearingType: string

--- a/server/data/HearingAndOutcomeResult.ts
+++ b/server/data/HearingAndOutcomeResult.ts
@@ -94,6 +94,7 @@ export enum ReferGovReason {
 export type HearingDetails = {
   id?: number
   locationId: number
+  locationUuid: string
   dateTimeOfHearing: string
   oicHearingType: string
   outcome?: HearingOutcomeDetails

--- a/server/data/PrisonLocationResult.ts
+++ b/server/data/PrisonLocationResult.ts
@@ -1,5 +1,5 @@
 export type PrisonLocation = {
-  locationId: number
+  locationId: number // TODO: MAP-2114: remove at a later date
   locationUuid: string
   locationPrefix: string
   userDescription: string
@@ -7,7 +7,7 @@ export type PrisonLocation = {
 
 export type AgencyId = string
 
-export type LocationId = number
+export type LocationId = number // TODO: MAP-2114: remove at a later date
 
 export type LocationUuid = string
 
@@ -17,7 +17,7 @@ export type Agency = {
 }
 
 export type Location = {
-  locationId: number
+  locationId: number // TODO: MAP-2114: remove at a later date
   locationUuid: string
   locationPrefix: string
   userDescription: string
@@ -25,7 +25,7 @@ export type Location = {
 }
 
 export type IncidentLocation = {
-  locationId: string
+  locationId: string // TODO: MAP-2114: remove at a later date
   locationUuid: string
   locationPrefix: string
   userDescription: string

--- a/server/data/PrisonLocationResult.ts
+++ b/server/data/PrisonLocationResult.ts
@@ -1,5 +1,6 @@
 export type PrisonLocation = {
   locationId: number
+  locationUuid: string
   locationPrefix: string
   userDescription: string
 }
@@ -8,6 +9,8 @@ export type AgencyId = string
 
 export type LocationId = number
 
+export type LocationUuid = string
+
 export type Agency = {
   agencyId: string
   description: string
@@ -15,6 +18,7 @@ export type Agency = {
 
 export type Location = {
   locationId: number
+  locationUuid: string
   locationPrefix: string
   userDescription: string
   agencyId: string
@@ -22,6 +26,7 @@ export type Location = {
 
 export type IncidentLocation = {
   locationId: string
+  locationUuid: string
   locationPrefix: string
   userDescription: string
   agencyId?: string

--- a/server/data/manageAdjudicationsSystemTokensClient.test.ts
+++ b/server/data/manageAdjudicationsSystemTokensClient.test.ts
@@ -94,6 +94,7 @@ describe('manageAdjudicationsSystemTokensClient', () => {
       }
       const details = {
         locationId: 2,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         dateTimeOfIncident: '2021-10-28T15:40:25.884',
         incidentRole: {
@@ -222,6 +223,7 @@ describe('manageAdjudicationsSystemTokensClient', () => {
     const editedDetails = {
       dateTimeOfIncident: '2021-11-04T09:21:00.00',
       locationId: 23424,
+      locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
       incidentRole: {
         roleCode: '25b',
         associatedPrisonersNumber: 'B2345BB',

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearing.test.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearing.test.ts
@@ -83,7 +83,7 @@ describe('POST new schedule hearing', () => {
       .post(adjudicationUrls.scheduleHearing.urls.start('1524494'))
       .send({
         hearingDate: { date: '03/11/2045', time: { hour: '11', minute: '00' } },
-        locationId: 27008,
+        locationId: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'GOV',
       })
@@ -107,7 +107,7 @@ describe('POST new schedule hearing', () => {
       .post(adjudicationUrls.scheduleHearing.urls.start('1524494'))
       .send({
         hearingDate: { date: '03/11/2045', time: { hour: '11', minute: '00' } },
-        locationId: 27008,
+        locationId: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'IND_ADJ',
       })

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearing.test.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearing.test.ts
@@ -84,6 +84,7 @@ describe('POST new schedule hearing', () => {
       .send({
         hearingDate: { date: '03/11/2045', time: { hour: '11', minute: '00' } },
         locationId: 27008,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'GOV',
       })
       .expect(302)
@@ -93,6 +94,7 @@ describe('POST new schedule hearing', () => {
         expect(reportedAdjudicationsService.scheduleHearing).toHaveBeenCalledWith(
           '1524494',
           27008,
+          '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           '2045-11-03T11:00',
           OicHearingType.GOV_ADULT as string,
           expect.anything()
@@ -106,6 +108,7 @@ describe('POST new schedule hearing', () => {
       .send({
         hearingDate: { date: '03/11/2045', time: { hour: '11', minute: '00' } },
         locationId: 27008,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'IND_ADJ',
       })
       .expect(302)
@@ -115,6 +118,7 @@ describe('POST new schedule hearing', () => {
         expect(reportedAdjudicationsService.scheduleHearing).toHaveBeenCalledWith(
           '1524494',
           27008,
+          '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           '2045-11-03T11:00',
           OicHearingType.INAD_ADULT as string,
           expect.anything()
@@ -129,6 +133,7 @@ describe('POST new schedule hearing', () => {
       .send({
         hearingDate: { date: '03/11/2045', time: { hour: '11', minute: '00' } },
         locationId: 27008,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'GOV',
       })
       .expect('Content-Type', /html/)

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingEdit.test.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingEdit.test.ts
@@ -93,7 +93,7 @@ describe('POST edit existing hearing', () => {
       .post(adjudicationUrls.scheduleHearing.urls.edit('1524494', 101))
       .send({
         hearingDate: { date: '04/11/2045', time: { hour: '10', minute: '00' } },
-        locationId: 27008,
+        locationId: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'GOV',
       })
@@ -119,7 +119,7 @@ describe('POST edit existing hearing', () => {
       .post(adjudicationUrls.scheduleHearing.urls.edit('1524494', 101))
       .send({
         hearingDate: { date: '04/11/2045', time: { hour: '10', minute: '00' } },
-        locationId: 27008,
+        locationId: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'IND_ADJ',
       })

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingEdit.test.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingEdit.test.ts
@@ -94,6 +94,7 @@ describe('POST edit existing hearing', () => {
       .send({
         hearingDate: { date: '04/11/2045', time: { hour: '10', minute: '00' } },
         locationId: 27008,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'GOV',
       })
       .expect(302)
@@ -103,6 +104,7 @@ describe('POST edit existing hearing', () => {
         expect(reportedAdjudicationsService.rescheduleHearing).toHaveBeenCalledWith(
           '1524494',
           27008,
+          '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           '2045-11-04T10:00',
           OicHearingType.GOV_ADULT as string,
           expect.anything()
@@ -118,6 +120,7 @@ describe('POST edit existing hearing', () => {
       .send({
         hearingDate: { date: '04/11/2045', time: { hour: '10', minute: '00' } },
         locationId: 27008,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         hearingType: 'IND_ADJ',
       })
       .expect(302)
@@ -127,6 +130,7 @@ describe('POST edit existing hearing', () => {
         expect(reportedAdjudicationsService.rescheduleHearing).toHaveBeenCalledWith(
           '1524494',
           27008,
+          '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           '2045-11-04T10:00',
           OicHearingType.INAD_ADULT as string,
           expect.anything()

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingPage.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingPage.ts
@@ -38,6 +38,8 @@ type HearingDetails = {
   hearingDate: SubmittedDateTime
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   locationId: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  locationUuid: any
   id?: number
   hearingType: string
 }
@@ -93,6 +95,7 @@ export default class scheduleHearingRoutes {
     const validationError = validateForm({
       hearingDate: postValues.hearingDetails.hearingDate,
       locationId: postValues.hearingDetails.locationId,
+      locationUuid: postValues.hearingDetails.locationUuid,
       hearingType: postValues.hearingDetails.hearingType,
       latestExistingHearing: latestHearing.dateTimeOfHearing,
     })
@@ -113,6 +116,7 @@ export default class scheduleHearingRoutes {
         await this.reportedAdjudicationsService.rescheduleHearing(
           chargeNumber,
           hearingDetailsToSave.locationId,
+          hearingDetailsToSave.locationUuid,
           formatDate(hearingDetailsToSave.hearingDate),
           getOICHearingType(hearingDetailsToSave.hearingType, isYOI),
           user
@@ -121,6 +125,7 @@ export default class scheduleHearingRoutes {
         await this.reportedAdjudicationsService.scheduleHearing(
           chargeNumber,
           hearingDetailsToSave.locationId,
+          hearingDetailsToSave.locationUuid,
           formatDate(hearingDetailsToSave.hearingDate),
           getOICHearingType(hearingDetailsToSave.hearingType, isYOI),
           user
@@ -145,9 +150,11 @@ export default class scheduleHearingRoutes {
     const { reportedAdjudication } = adjudication
     const [hearingToRender] = reportedAdjudication.hearings.filter(hearing => hearing.id === hearingId)
     const locationId = await this.locationService.getCorrespondingDpsLocationId(hearingToRender.locationId, user)
+    const locationUuid = await this.locationService.getIncidentLocation(hearingToRender.locationUuid, user)
     return {
-      hearingDate: await convertDateTimeStringToSubmittedDateTime(hearingToRender.dateTimeOfHearing),
+      hearingDate: convertDateTimeStringToSubmittedDateTime(hearingToRender.dateTimeOfHearing),
       locationId,
+      locationUuid,
       id: hearingToRender.id,
       hearingType: getRadioHearingType(hearingToRender.oicHearingType),
     }
@@ -181,6 +188,7 @@ const renderData = (res: Response, pageData: PageData, error: FormError[]) => {
   const data = {
     hearingDate: convertSubmittedDateTimeToDateObject(pageData.formData.hearingDetails?.hearingDate),
     locationId: pageData.formData.hearingDetails?.locationId,
+    locationUuid: pageData.formData.hearingDetails?.locationUuid,
     hearingType: pageData.formData.hearingDetails?.hearingType,
   }
 
@@ -198,6 +206,7 @@ const extractValuesFromPost = (req: Request): SubmittedFormData => {
     hearingDetails: {
       hearingDate: req.body.hearingDate,
       locationId: req.body.locationId,
+      locationUuid: req.body.locationUuid,
       hearingType: req.body.hearingType,
     },
   }

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingPage.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingPage.ts
@@ -37,7 +37,7 @@ type PageData = {
 type HearingDetails = {
   hearingDate: SubmittedDateTime
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  locationId: any
+  locationId: any // TODO: MAP-2114: remove at a later date
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   locationUuid: any
   id?: number
@@ -94,7 +94,7 @@ export default class scheduleHearingRoutes {
     )
     const validationError = validateForm({
       hearingDate: postValues.hearingDetails.hearingDate,
-      locationId: postValues.hearingDetails.locationId,
+      locationId: postValues.hearingDetails.locationId, // TODO: MAP-2114: remove at a later date
       locationUuid: postValues.hearingDetails.locationUuid,
       hearingType: postValues.hearingDetails.hearingType,
       latestExistingHearing: latestHearing.dateTimeOfHearing,
@@ -115,7 +115,7 @@ export default class scheduleHearingRoutes {
       if (this.pageOptions.isEdit()) {
         await this.reportedAdjudicationsService.rescheduleHearing(
           chargeNumber,
-          hearingDetailsToSave.locationId,
+          hearingDetailsToSave.locationId, // TODO: MAP-2114: remove at a later date
           hearingDetailsToSave.locationUuid,
           formatDate(hearingDetailsToSave.hearingDate),
           getOICHearingType(hearingDetailsToSave.hearingType, isYOI),
@@ -124,7 +124,7 @@ export default class scheduleHearingRoutes {
       } else {
         await this.reportedAdjudicationsService.scheduleHearing(
           chargeNumber,
-          hearingDetailsToSave.locationId,
+          hearingDetailsToSave.locationId, // TODO: MAP-2114: remove at a later date
           hearingDetailsToSave.locationUuid,
           formatDate(hearingDetailsToSave.hearingDate),
           getOICHearingType(hearingDetailsToSave.hearingType, isYOI),
@@ -153,7 +153,7 @@ export default class scheduleHearingRoutes {
     const locationUuid = await this.locationService.getIncidentLocation(hearingToRender.locationUuid, user)
     return {
       hearingDate: convertDateTimeStringToSubmittedDateTime(hearingToRender.dateTimeOfHearing),
-      locationId,
+      locationId, // TODO: MAP-2114: remove at a later date
       locationUuid,
       id: hearingToRender.id,
       hearingType: getRadioHearingType(hearingToRender.oicHearingType),
@@ -187,7 +187,7 @@ export default class scheduleHearingRoutes {
 const renderData = (res: Response, pageData: PageData, error: FormError[]) => {
   const data = {
     hearingDate: convertSubmittedDateTimeToDateObject(pageData.formData.hearingDetails?.hearingDate),
-    locationId: pageData.formData.hearingDetails?.locationId,
+    locationId: pageData.formData.hearingDetails?.locationId, // TODO: MAP-2114: remove at a later date
     locationUuid: pageData.formData.hearingDetails?.locationUuid,
     hearingType: pageData.formData.hearingDetails?.hearingType,
   }
@@ -205,8 +205,8 @@ const extractValuesFromPost = (req: Request): SubmittedFormData => {
   const values = {
     hearingDetails: {
       hearingDate: req.body.hearingDate,
-      locationId: req.body.locationId,
-      locationUuid: req.body.locationUuid,
+      locationId: req.body.locationId, // TODO: MAP-2114: remove at a later date
+      locationUuid: req.body.locationId,
       hearingType: req.body.hearingType,
     },
   }

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingValidation.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingValidation.ts
@@ -3,7 +3,7 @@ import { formatDate, formatTimestampToDate, formatTimestampToTime } from '../../
 
 type ScheduleHearingForm = {
   hearingDate?: SubmittedDateTime
-  locationId?: string
+  locationId?: string // TODO: MAP-2114: remove at a later date
   locationUuid?: string
   hearingType?: string
   latestExistingHearing?: string

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingValidation.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingValidation.ts
@@ -4,6 +4,7 @@ import { formatDate, formatTimestampToDate, formatTimestampToTime } from '../../
 type ScheduleHearingForm = {
   hearingDate?: SubmittedDateTime
   locationId?: string
+  locationUuid?: string
   hearingType?: string
   latestExistingHearing?: string
 }

--- a/server/routes/checkYourAnswers/checkYourAnswersBeforeChangeReporter.test.ts
+++ b/server/routes/checkYourAnswers/checkYourAnswersBeforeChangeReporter.test.ts
@@ -57,7 +57,13 @@ beforeEach(() => {
   })
 
   locationService.getIncidentLocations.mockResolvedValue([
-    { locationId: 'location-6', locationPrefix: 'OC', userDescription: 'Rivendell', agencyId: 'NMI' },
+    {
+      locationId: 'location-6',
+      locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
+      locationPrefix: 'OC',
+      userDescription: 'Rivendell',
+      agencyId: 'NMI',
+    },
   ])
 
   placeOnReportService.getCheckYourAnswersInfo.mockResolvedValue({

--- a/server/routes/incidentDetails/incidentDetails.test.ts
+++ b/server/routes/incidentDetails/incidentDetails.test.ts
@@ -71,6 +71,7 @@ describe('POST /incident-details', () => {
         incidentDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
         discoveryDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
         locationId: 2,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         currentRadioSelected: 'incited',
         incitedInput: 'G2678PF',
         discoveryRadioSelected: 'Yes',
@@ -84,6 +85,7 @@ describe('POST /incident-details', () => {
       .send({
         incidentDate: { date: '27/10/2021', time: { hour: '66', minute: '30' } },
         locationId: 2,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         discoveryRadioSelected: 'Yes',
       })
       .expect('Content-Type', /html/)
@@ -100,6 +102,7 @@ describe('POST /incident-details', () => {
         incidentDate: { date: '27/10/2021', time: { hour: '12', minute: '30' } },
         discoveryDate: { date: '27/10/2021', time: { hour: '12', minute: '30' } },
         locationId: 2,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         currentRadioSelected: 'incited',
         incitedInput: 'G2678PF',
         discoveryRadioSelected: 'Yes',
@@ -117,7 +120,8 @@ describe('POST /incident-details', () => {
       .send({
         incidentDate: { date: '26/10/2021', time: { hour: '13', minute: '30' } },
         discoveryDate: { date: '', time: { hour: '', minute: '' } },
-        locationId: 2,
+        locationId: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         currentRadioSelected: 'incited',
         incitedInput: 'G2678PF',
         discoveryRadioSelected: 'Yes',
@@ -126,6 +130,7 @@ describe('POST /incident-details', () => {
         expect(placeOnReportService.startNewDraftAdjudication).toBeCalledWith(
           '2021-10-26T13:30',
           2,
+          '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           'G6415GD',
           expect.anything(),
           PrisonerGender.MALE,
@@ -149,7 +154,8 @@ describe('POST /incident-details', () => {
       .send({
         incidentDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
         discoveryDate: { date: '27/10/2021', time: { hour: '13', minute: '30' } },
-        locationId: 2,
+        locationId: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         currentRadioSelected: 'incited',
         incitedInput: 'G2678PF',
         discoveryRadioSelected: 'Yes',
@@ -161,6 +167,7 @@ describe('POST /incident-details', () => {
         expect(placeOnReportService.startNewDraftAdjudication).toBeCalledWith(
           '2021-10-27T13:30',
           2,
+          '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           'G6415GD',
           expect.anything(),
           PrisonerGender.MALE,

--- a/server/routes/incidentDetails/incidentDetailsPage.ts
+++ b/server/routes/incidentDetails/incidentDetailsPage.ts
@@ -60,6 +60,7 @@ type IncidentDetails = {
   incidentDate: SubmittedDateTime
   discoveryDate: SubmittedDateTime
   locationId: string | number
+  locationUuid: string
   discoveryRadioSelected?: string
 }
 
@@ -131,6 +132,7 @@ export default class IncidentDetailsPage {
       incidentDate: postValues.incidentDetails?.incidentDate,
       discoveryDate: postValues.incidentDetails?.discoveryDate,
       locationId: postValues.incidentDetails?.locationId as string,
+      locationUuid: postValues.incidentDetails?.locationUuid as string,
       discoveryRadioSelected: postValues.incidentDetails?.discoveryRadioSelected,
     })
     if (validationError) {
@@ -195,6 +197,7 @@ export default class IncidentDetailsPage {
     return await this.placeOnReportService.startNewDraftAdjudication(
       formatDate(data.incidentDate),
       data.locationId as number,
+      data.locationUuid,
       prisonerNumber,
       currentUser,
       data.gender,
@@ -212,6 +215,7 @@ export default class IncidentDetailsPage {
       draftId,
       formatDate(data.incidentDate),
       data.locationId as number,
+      data.locationUuid,
       currentUser,
       formatDate(data.discoveryDate)
     )
@@ -338,6 +342,7 @@ const extractIncidentDetails = (readDraftIncidentDetails: ExistingDraftIncidentD
     incidentDate: readDraftIncidentDetails.dateTime,
     discoveryDate: radioValue === 'Yes' ? null : readDraftIncidentDetails.dateTimeOfDiscovery,
     locationId: readDraftIncidentDetails.locationId,
+    locationUuid: readDraftIncidentDetails.locationUuid,
     discoveryRadioSelected: radioValue,
     reporterUsername: readDraftIncidentDetails.startedByUserId,
   }
@@ -355,6 +360,7 @@ const extractValuesFromPost = (req: Request): SubmittedFormData => {
       incidentDate: req.body.incidentDate,
       discoveryDate: discoveryDateTime,
       locationId: req.body.locationId,
+      locationUuid: req.body.locationId,
       reporterUsername: req.body.originalReporterUsername,
       discoveryRadioSelected: req.body.discoveryRadioSelected,
     },
@@ -377,6 +383,7 @@ const renderData = (res: Response, pageData: PageData, error: FormError) => {
     incidentDate: convertSubmittedDateTimeToDateObject(pageData.formData.incidentDetails?.incidentDate),
     discoveryDate: convertSubmittedDateTimeToDateObject(pageData.formData.incidentDetails?.discoveryDate),
     locationId: pageData.formData.incidentDetails?.locationId,
+    locationUuid: pageData.formData.incidentDetails?.locationId,
     discoveryRadioSelected: pageData.formData.incidentDetails?.discoveryRadioSelected,
   }
   return res.render(`pages/incidentDetails`, {

--- a/server/routes/incidentDetails/incidentDetailsPage.ts
+++ b/server/routes/incidentDetails/incidentDetailsPage.ts
@@ -59,7 +59,7 @@ type RequestValues = {
 type IncidentDetails = {
   incidentDate: SubmittedDateTime
   discoveryDate: SubmittedDateTime
-  locationId: string | number
+  locationId: string | number // TODO: MAP-2114: remove at a later date
   locationUuid: string
   discoveryRadioSelected?: string
 }
@@ -131,7 +131,7 @@ export default class IncidentDetailsPage {
     const validationError = validateForm({
       incidentDate: postValues.incidentDetails?.incidentDate,
       discoveryDate: postValues.incidentDetails?.discoveryDate,
-      locationId: postValues.incidentDetails?.locationId as string,
+      locationId: postValues.incidentDetails?.locationId as string, // TODO: MAP-2114: remove at a later date
       locationUuid: postValues.incidentDetails?.locationUuid as string,
       discoveryRadioSelected: postValues.incidentDetails?.discoveryRadioSelected,
     })
@@ -196,7 +196,7 @@ export default class IncidentDetailsPage {
     // eslint-disable-next-line no-return-await
     return await this.placeOnReportService.startNewDraftAdjudication(
       formatDate(data.incidentDate),
-      data.locationId as number,
+      data.locationId as number, // TODO: MAP-2114: remove at a later date
       data.locationUuid,
       prisonerNumber,
       currentUser,
@@ -214,7 +214,7 @@ export default class IncidentDetailsPage {
     return await this.placeOnReportService.editDraftIncidentDetails(
       draftId,
       formatDate(data.incidentDate),
-      data.locationId as number,
+      data.locationId as number, // TODO: MAP-2114: remove at a later date
       data.locationUuid,
       currentUser,
       formatDate(data.discoveryDate)
@@ -341,7 +341,7 @@ const extractIncidentDetails = (readDraftIncidentDetails: ExistingDraftIncidentD
   return {
     incidentDate: readDraftIncidentDetails.dateTime,
     discoveryDate: radioValue === 'Yes' ? null : readDraftIncidentDetails.dateTimeOfDiscovery,
-    locationId: readDraftIncidentDetails.locationId,
+    locationId: readDraftIncidentDetails.locationId, // TODO: MAP-2114: remove at a later date
     locationUuid: readDraftIncidentDetails.locationUuid,
     discoveryRadioSelected: radioValue,
     reporterUsername: readDraftIncidentDetails.startedByUserId,
@@ -359,7 +359,7 @@ const extractValuesFromPost = (req: Request): SubmittedFormData => {
     incidentDetails: {
       incidentDate: req.body.incidentDate,
       discoveryDate: discoveryDateTime,
-      locationId: req.body.locationId,
+      locationId: req.body.locationId, // TODO: MAP-2114: remove at a later date
       locationUuid: req.body.locationId,
       reporterUsername: req.body.originalReporterUsername,
       discoveryRadioSelected: req.body.discoveryRadioSelected,
@@ -382,7 +382,7 @@ const renderData = (res: Response, pageData: PageData, error: FormError) => {
   const data = {
     incidentDate: convertSubmittedDateTimeToDateObject(pageData.formData.incidentDetails?.incidentDate),
     discoveryDate: convertSubmittedDateTimeToDateObject(pageData.formData.incidentDetails?.discoveryDate),
-    locationId: pageData.formData.incidentDetails?.locationId,
+    locationId: pageData.formData.incidentDetails?.locationId, // TODO: MAP-2114: remove at a later date
     locationUuid: pageData.formData.incidentDetails?.locationId,
     discoveryRadioSelected: pageData.formData.incidentDetails?.discoveryRadioSelected,
   }

--- a/server/routes/incidentDetails/incidentDetailsValidation.test.ts
+++ b/server/routes/incidentDetails/incidentDetailsValidation.test.ts
@@ -7,6 +7,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '12', minute: '23' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -20,6 +21,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { time: { hour: '12', minute: '23' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -35,6 +37,7 @@ describe('validateForm', () => {
           incidentDate: { time: { hour: '12', minute: '23' } },
           discoveryDate: { date: '' },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: '',
@@ -50,6 +53,7 @@ describe('validateForm', () => {
           incidentDate: { time: { hour: '12', minute: '23' } },
           discoveryDate: { date: '', time: { hour: '', minute: '' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'No',
@@ -65,6 +69,7 @@ describe('validateForm', () => {
           incidentDate: { time: { hour: '', minute: '23' } },
           discoveryDate: { date: '20/12/2022', time: { hour: '', minute: '23' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'No',
@@ -88,6 +93,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { minute: '23' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -102,6 +108,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '65', minute: '23' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -116,6 +123,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '12' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -130,6 +138,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '12', minute: '65' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -144,6 +153,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: {} },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -158,6 +168,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '8', minute: '30' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -172,6 +183,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '008', minute: '30' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -186,6 +198,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '08', minute: '1' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -200,6 +213,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '08', minute: '001' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -214,6 +228,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: 'lll', minute: '50' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -228,6 +243,7 @@ describe('validateForm', () => {
         validateForm({
           incidentDate: { date: '31/10/2021', time: { hour: '09', minute: 'fffff' } },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',
@@ -247,6 +263,7 @@ describe('validateForm', () => {
             time: { hour: `09`, minute: `22` },
           },
           locationId: 'location-id-1',
+          locationUuid: 'location-uuid-1',
           incidentRole: 'attempted',
           associatedPrisonersNumber: 'GF456CU',
           discoveryRadioSelected: 'Yes',

--- a/server/routes/incidentDetails/incidentDetailsValidation.ts
+++ b/server/routes/incidentDetails/incidentDetailsValidation.ts
@@ -4,7 +4,7 @@ import { formatDate } from '../../utils/utils'
 type incidentDetailsForm = {
   incidentDate?: SubmittedDateTime
   discoveryDate?: SubmittedDateTime
-  locationId?: string
+  locationId?: string // TODO: MAP-2114: remove at a later date
   locationUuid?: string
   incidentRole?: string
   associatedPrisonersNumber?: string
@@ -89,7 +89,7 @@ const errors: { [key: string]: FormError } = {
 export default function validateForm({
   incidentDate,
   discoveryDate,
-  locationId,
+  locationId, // TODO: MAP-2114: remove at a later date
   locationUuid,
   discoveryRadioSelected,
 }: incidentDetailsForm): FormError | null {
@@ -144,7 +144,7 @@ export default function validateForm({
     return errors.MISSING_MINUTE
   }
   if (!locationId) {
-    return errors.MISSING_LOCATION
+    return errors.MISSING_LOCATION // TODO: MAP-2114: remove at a later date
   }
   if (!locationUuid) {
     return errors.MISSING_LOCATION

--- a/server/routes/incidentDetails/incidentDetailsValidation.ts
+++ b/server/routes/incidentDetails/incidentDetailsValidation.ts
@@ -5,6 +5,7 @@ type incidentDetailsForm = {
   incidentDate?: SubmittedDateTime
   discoveryDate?: SubmittedDateTime
   locationId?: string
+  locationUuid?: string
   incidentRole?: string
   associatedPrisonersNumber?: string
   discoveryRadioSelected?: string
@@ -89,6 +90,7 @@ export default function validateForm({
   incidentDate,
   discoveryDate,
   locationId,
+  locationUuid,
   discoveryRadioSelected,
 }: incidentDetailsForm): FormError | null {
   if (!discoveryRadioSelected) {
@@ -142,6 +144,9 @@ export default function validateForm({
     return errors.MISSING_MINUTE
   }
   if (!locationId) {
+    return errors.MISSING_LOCATION
+  }
+  if (!locationUuid) {
     return errors.MISSING_LOCATION
   }
   if (Number.isNaN(Number(incidentDate.time.hour)) || Number(incidentDate.time.hour) > 23) {

--- a/server/routes/incidentStatement/incidentStatement.test.ts
+++ b/server/routes/incidentStatement/incidentStatement.test.ts
@@ -19,6 +19,7 @@ const draftAdjudication = (statement: { statement: string; completed: boolean })
     prisonerNumber: 'A7937DY',
     incidentDetails: {
       locationId: 1,
+      locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
       dateTimeOfIncident: '2023-01-01T06:00:00',
     },
     incidentStatement: statement,

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -51,6 +51,7 @@ export default class TestData {
     dateTimeOfDiscovery = dateTimeOfIncident,
     handoverDeadline,
     locationId = 1,
+    locationUuid = '0194ac90-2def-7c63-9f46-b3ccc911fdff',
     incidentStatement = {} as IncidentStatement,
     offenceDetails = {} as OffenceDetails,
     incidentRole = {} as IncidentRole,
@@ -82,6 +83,7 @@ export default class TestData {
     dateTimeOfDiscovery?: string
     handoverDeadline?: string
     locationId?: number
+    locationUuid?: string
     incidentStatement?: IncidentStatement
     offenceDetails?: OffenceDetails
     incidentRole?: IncidentRole
@@ -115,6 +117,7 @@ export default class TestData {
         dateTimeOfDiscovery,
         handoverDeadline,
         locationId,
+        locationUuid,
       },
       incidentStatement,
       offenceDetails,
@@ -151,6 +154,7 @@ export default class TestData {
     prisonerNumber,
     gender = PrisonerGender.MALE,
     locationId = 1,
+    locationUuid = '0194ac90-2def-7c63-9f46-b3ccc911fdff',
     dateTimeOfIncident = '2023-01-01T06:00:00',
     dateTimeOfDiscovery = dateTimeOfIncident,
     offenceDetails = {} as OffenceDetails,
@@ -171,6 +175,7 @@ export default class TestData {
     prisonerNumber: string
     gender?: PrisonerGender
     locationId?: number
+    locationUuid?: string
     dateTimeOfIncident?: string
     dateTimeOfDiscovery?: string
     offenceDetails?: OffenceDetails
@@ -194,6 +199,7 @@ export default class TestData {
       gender,
       incidentDetails: {
         locationId,
+        locationUuid,
         dateTimeOfIncident,
         dateTimeOfDiscovery,
         handoverDeadline: moment(dateTimeOfDiscovery).add(2, 'days').format('YYYY-MM-DDTHH:mm'),
@@ -217,24 +223,28 @@ export default class TestData {
     return [
       {
         locationId: 25538,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-1',
         userDescription: 'Houseblock 1',
       },
       {
         locationId: 25655,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-2',
         userDescription: 'Houseblock 2',
       },
       {
         locationId: 26956,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-RECEP',
         userDescription: 'Reception',
       },
       {
         locationId: 27102,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-MCASU',
         userDescription: 'Segregation MPU',
@@ -269,24 +279,28 @@ export default class TestData {
     return [
       {
         locationId: 'location-1',
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-1',
         userDescription: 'Houseblock 1',
       },
       {
         locationId: 'location-2',
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-2',
         userDescription: 'Houseblock 2',
       },
       {
         locationId: 'location-recep',
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-RECEP',
         userDescription: 'Reception',
       },
       {
         locationId: 'location-seg',
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         agencyId: 'MDI',
         locationPrefix: 'MDI-MCASU',
         userDescription: 'Segregation MPU',
@@ -313,6 +327,7 @@ export default class TestData {
     outcome,
     id = 101,
     locationId = 775,
+    locationUuid = '0194ac90-2def-7c63-9f46-b3ccc911fdff',
     oicHearingType = OicHearingType.GOV_ADULT,
     agencyId = 'MDI',
   }: {
@@ -320,12 +335,14 @@ export default class TestData {
     outcome?: HearingOutcomeResult
     id?: number
     locationId?: number
+    locationUuid?: string
     oicHearingType?: OicHearingType
     agencyId?: string
   }): HearingDetails => {
     return {
       id,
       locationId,
+      locationUuid,
       dateTimeOfHearing,
       oicHearingType,
       agencyId,

--- a/server/services/locationService.test.ts
+++ b/server/services/locationService.test.ts
@@ -44,11 +44,41 @@ describe('locationService', () => {
     })
     it('should assign internalLocationCode as userDescription when userDescription value is absent', async () => {
       getLocations.mockReturnValue([
-        { id: 'location-uuid-1', localName: 'Place 1', key: 'MDI-1', prisonId: 'MDI' },
-        { id: 'location-uuid-2', localName: 'Other cell', key: 'MDI-2', prisonId: 'MDI' },
-        { id: 'location-uuid-3', localName: "Prisoner's cell", key: 'MDI-3', prisonId: 'MDI' },
-        { id: 'location-uuid-4', localName: undefined, key: 'MDI-4', prisonId: 'MDI' },
-        { id: 'location-uuid-5', localName: 'Place 5', key: 'MDI-5', prisonId: 'MDI' },
+        {
+          id: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
+          localName: 'Place 1',
+          key: 'MDI-1',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
+          localName: 'Other cell',
+          key: 'MDI-2',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
+          localName: "Prisoner's cell",
+          key: 'MDI-3',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
+          localName: undefined,
+          key: 'MDI-4',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
+          localName: 'Place 5',
+          key: 'MDI-5',
+          prisonId: 'MDI',
+        },
       ])
 
       const result = await service.getIncidentLocations('MDI', user)
@@ -57,30 +87,35 @@ describe('locationService', () => {
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
           locationPrefix: 'MDI-3',
           userDescription: "Prisoner's cell",
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
           locationPrefix: 'MDI-2',
           userDescription: 'Other cell',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
           locationPrefix: 'MDI-4',
           userDescription: 'MDI-4',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
           locationPrefix: 'MDI-1',
           userDescription: 'Place 1',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
           locationPrefix: 'MDI-5',
           userDescription: 'Place 5',
         },
@@ -88,12 +123,48 @@ describe('locationService', () => {
     })
     it('should sort retrieved locations with top 2 primary locations at the begining', async () => {
       getLocations.mockReturnValue([
-        { id: 'location-uuid-2', localName: 'place 2', key: 'MDI-place-2', prisonId: 'MDI' },
-        { id: 'location-uuid-6', localName: 'Other cell', key: 'MDI-some-cell', prisonId: 'MDI' },
-        { id: 'location-uuid-3', localName: 'place 3', key: 'MDI-cell-3', prisonId: 'MDI' },
-        { id: 'location-uuid-5', localName: "Prisoner's cell", key: 'MDI-cell-5', prisonId: 'MDI' },
-        { id: 'location-uuid-1', localName: 'place 1', key: 'MDI-place-1', prisonId: 'MDI' },
-        { id: 'location-uuid-4', localName: 'place 4', key: 'MDI-place-4', prisonId: 'MDI' },
+        {
+          id: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
+          localName: 'place 2',
+          key: 'MDI-place-2',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-6',
+          locationUuid: 'location-uuid-6',
+          localName: 'Other cell',
+          key: 'MDI-some-cell',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
+          localName: 'place 3',
+          key: 'MDI-cell-3',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
+          localName: "Prisoner's cell",
+          key: 'MDI-cell-5',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
+          localName: 'place 1',
+          key: 'MDI-place-1',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
+          localName: 'place 4',
+          key: 'MDI-place-4',
+          prisonId: 'MDI',
+        },
       ])
 
       const result = await service.getIncidentLocations('WRI', user)
@@ -102,36 +173,42 @@ describe('locationService', () => {
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
           locationPrefix: 'MDI-cell-5',
           userDescription: "Prisoner's cell",
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-6',
+          locationUuid: 'location-uuid-6',
           locationPrefix: 'MDI-some-cell',
           userDescription: 'Other cell',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
           locationPrefix: 'MDI-place-1',
           userDescription: 'place 1',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
           locationPrefix: 'MDI-place-2',
           userDescription: 'place 2',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
           locationPrefix: 'MDI-cell-3',
           userDescription: 'place 3',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
           locationPrefix: 'MDI-place-4',
           userDescription: 'place 4',
         },
@@ -139,11 +216,41 @@ describe('locationService', () => {
     })
     it('should sort retrieved locations with only 1 primary location at the begining', async () => {
       getLocations.mockReturnValue([
-        { id: 'location-uuid-2', localName: 'place 2', key: 'MDI-place-2', prisonId: 'MDI' },
-        { id: 'location-uuid-3', localName: 'place 3', key: 'MDI-cell-3', prisonId: 'MDI' },
-        { id: 'location-uuid-5', localName: "Prisoner's cell", key: 'MDI-cell-5', prisonId: 'MDI' },
-        { id: 'location-uuid-1', localName: 'place 1', key: 'MDI-place-1', prisonId: 'MDI' },
-        { id: 'location-uuid-4', localName: 'place 4', key: 'MDI-place-4', prisonId: 'MDI' },
+        {
+          id: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
+          localName: 'place 2',
+          key: 'MDI-place-2',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
+          localName: 'place 3',
+          key: 'MDI-cell-3',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
+          localName: "Prisoner's cell",
+          key: 'MDI-cell-5',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
+          localName: 'place 1',
+          key: 'MDI-place-1',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
+          localName: 'place 4',
+          key: 'MDI-place-4',
+          prisonId: 'MDI',
+        },
       ])
 
       const result = await service.getIncidentLocations('WRI', user)
@@ -152,30 +259,35 @@ describe('locationService', () => {
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
           locationPrefix: 'MDI-cell-5',
           userDescription: "Prisoner's cell",
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
           locationPrefix: 'MDI-place-1',
           userDescription: 'place 1',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
           locationPrefix: 'MDI-place-2',
           userDescription: 'place 2',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
           locationPrefix: 'MDI-cell-3',
           userDescription: 'place 3',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
           locationPrefix: 'MDI-place-4',
           userDescription: 'place 4',
         },
@@ -184,10 +296,34 @@ describe('locationService', () => {
 
     it('should sort retrieved locations with zero primary locations at the begining', async () => {
       getLocations.mockReturnValue([
-        { id: 'location-uuid-1', localName: 'place 1', key: 'MDI-place-1', prisonId: 'MDI' },
-        { id: 'location-uuid-2', localName: 'place 2', key: 'MDI-place-2', prisonId: 'MDI' },
-        { id: 'location-uuid-3', localName: 'place 3', key: 'MDI-cell-3', prisonId: 'MDI' },
-        { id: 'location-uuid-4', localName: 'place 4', key: 'MDI-place-4', prisonId: 'MDI' },
+        {
+          id: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
+          localName: 'place 1',
+          key: 'MDI-place-1',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
+          localName: 'place 2',
+          key: 'MDI-place-2',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
+          localName: 'place 3',
+          key: 'MDI-cell-3',
+          prisonId: 'MDI',
+        },
+        {
+          id: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
+          localName: 'place 4',
+          key: 'MDI-place-4',
+          prisonId: 'MDI',
+        },
       ])
 
       const result = await service.getIncidentLocations('WRI', user)
@@ -196,24 +332,28 @@ describe('locationService', () => {
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
           locationPrefix: 'MDI-place-1',
           userDescription: 'place 1',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
           locationPrefix: 'MDI-place-2',
           userDescription: 'place 2',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
           locationPrefix: 'MDI-cell-3',
           userDescription: 'place 3',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
           locationPrefix: 'MDI-place-4',
           userDescription: 'place 4',
         },
@@ -221,8 +361,8 @@ describe('locationService', () => {
     })
     it('should sort retrieved locations with zero other locations', async () => {
       getLocations.mockReturnValue([
-        { id: 'location-uuid-6', localName: 'Other cell' },
-        { id: 'location-uuid-5', localName: "Prisoner's cell" },
+        { id: 'location-uuid-6', locationUuid: 'location-uuid-6', localName: 'Other cell' },
+        { id: 'location-uuid-5', locationUuid: 'location-uuid-5', localName: "Prisoner's cell" },
       ])
 
       const result = await service.getIncidentLocations('WRI', user)
@@ -231,12 +371,14 @@ describe('locationService', () => {
         {
           agencyId: undefined,
           locationId: 'location-uuid-5',
+          locationUuid: 'location-uuid-5',
           locationPrefix: undefined,
           userDescription: "Prisoner's cell",
         },
         {
           agencyId: undefined,
           locationId: 'location-uuid-6',
+          locationUuid: 'location-uuid-6',
           locationPrefix: undefined,
           userDescription: 'Other cell',
         },
@@ -272,24 +414,28 @@ describe('locationService', () => {
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
           locationPrefix: 'ab',
           userDescription: 'ab',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
           locationPrefix: 'gh',
           userDescription: 'gh',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
           locationPrefix: 'ef',
           userDescription: 'place 1',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
           locationPrefix: 'cd',
           userDescription: 'place 3',
         },
@@ -309,24 +455,28 @@ describe('locationService', () => {
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-1',
+          locationUuid: 'location-uuid-1',
           locationPrefix: 'ef',
           userDescription: 'place 1',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-2',
+          locationUuid: 'location-uuid-2',
           locationPrefix: 'ab',
           userDescription: 'place-2',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-3',
+          locationUuid: 'location-uuid-3',
           locationPrefix: 'cd',
           userDescription: 'place 3',
         },
         {
           agencyId: 'MDI',
           locationId: 'location-uuid-4',
+          locationUuid: 'location-uuid-4',
           locationPrefix: 'gh',
           userDescription: 'place-4',
         },

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -43,6 +43,7 @@ export default class LocationService {
     // mapping the reponse from locationsApi with that previosuly received from prisonApi
     const incidentLocations = locations.map(loc => ({
       locationId: loc.id,
+      locationUuid: loc.id,
       userDescription: loc.localName,
       locationPrefix: loc.key,
       agencyId: loc.prisonId,
@@ -73,7 +74,13 @@ export default class LocationService {
     const locations = await new LocationsInsidePrisonApiClient(token).getAdjudicationLocations(agencyId)
 
     const hearingLocations = locations.map(loc => {
-      return { locationId: loc.id, userDescription: loc.localName, locationPrefix: loc.key, agencyId: loc.prisonId }
+      return {
+        locationId: loc.id,
+        locationUuid: loc.id,
+        userDescription: loc.localName,
+        locationPrefix: loc.key,
+        agencyId: loc.prisonId,
+      }
     })
     const formattedHearingLocations = assignIntLocCodeAsUserDesc(hearingLocations)
 

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -42,7 +42,7 @@ export default class LocationService {
     const locations = await new LocationsInsidePrisonApiClient(token).getLocations(agencyId)
     // mapping the reponse from locationsApi with that previosuly received from prisonApi
     const incidentLocations = locations.map(loc => ({
-      locationId: loc.id,
+      locationId: loc.id, // TODO: MAP-2114: This is currently the Uuid - remove at a later date
       locationUuid: loc.id,
       userDescription: loc.localName,
       locationPrefix: loc.key,
@@ -75,7 +75,7 @@ export default class LocationService {
 
     const hearingLocations = locations.map(loc => {
       return {
-        locationId: loc.id,
+        locationId: loc.id, // TODO: MAP-2114: This is currently the Uuid - remove at a later date
         locationUuid: loc.id,
         userDescription: loc.localName,
         locationPrefix: loc.key,

--- a/server/services/placeOnReportService.test.ts
+++ b/server/services/placeOnReportService.test.ts
@@ -89,6 +89,7 @@ describe('placeOnReportService', () => {
       startNewDraftAdjudication.mockResolvedValue({
         draftAdjudication: testData.draftAdjudication({
           id: 1,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           chargeNumber: '4567123',
           prisonerNumber: 'G2996UX',
           dateTimeOfIncident: '2021-10-28T15:40:25.884',
@@ -98,6 +99,7 @@ describe('placeOnReportService', () => {
       const result = await service.startNewDraftAdjudication(
         '2021-10-28T15:40:25.884',
         3,
+        '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         'G2996UX',
         user,
         PrisonerGender.MALE,
@@ -107,6 +109,7 @@ describe('placeOnReportService', () => {
         dateTimeOfIncident: '2021-10-28T15:40:25.884',
         dateTimeOfDiscovery: '2021-10-29T15:40:25.884',
         locationId: 3,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         prisonerNumber: 'G2996UX',
         agencyId: 'MDI',
         gender: PrisonerGender.MALE,
@@ -135,6 +138,7 @@ describe('placeOnReportService', () => {
       await service.startNewDraftAdjudication(
         '2021-10-28T15:40:25.884',
         3,
+        '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         'G2996UX',
         user,
         PrisonerGender.MALE,
@@ -144,6 +148,7 @@ describe('placeOnReportService', () => {
         dateTimeOfIncident: '2021-10-28T15:40:25.884',
         dateTimeOfDiscovery: '2021-10-29T15:40:25.884',
         locationId: 3,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         prisonerNumber: 'G2996UX',
         agencyId: 'MDI',
         gender: PrisonerGender.MALE,
@@ -171,6 +176,7 @@ describe('placeOnReportService', () => {
           dateTimeOfIncident: '2021-11-04T07:20:00',
           dateTimeOfDiscovery: '2021-11-05T07:20:00',
           locationId: 25538,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           incidentStatement: {
             statement:
               "John didn't want to go to chapel today. He pushed over some pews and threw things on the floor.",
@@ -231,6 +237,7 @@ describe('placeOnReportService', () => {
           dateTimeOfIncident: '2021-11-04T07:20:00',
           dateTimeOfDiscovery: '2021-11-05T07:21:00',
           locationId: 25655,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           incidentStatement: {
             statement:
               "John didn't want to go to chapel today. He pushed over some pews and threw things on the floor.",
@@ -291,6 +298,7 @@ describe('placeOnReportService', () => {
           dateTimeOfIncident: '2021-11-04T07:20:00',
           dateTimeOfDiscovery: '2021-11-05T07:21:00',
           locationId: 25655,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           incidentStatement: {
             statement:
               "John didn't want to go to chapel today. He pushed over some pews and threw things on the floor.",
@@ -395,6 +403,7 @@ describe('placeOnReportService', () => {
         prisonerNumber: 'A12345',
         dateTimeOfIncident: '2020-12-10T10:00:00',
         locationId: 2,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         incidentStatement: {
           statement: 'This is a statement',
         },
@@ -410,6 +419,7 @@ describe('placeOnReportService', () => {
           prisonerNumber: 'A12345',
           dateTimeOfIncident: '2020-12-10T10:00:00',
           locationId: 2,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           incidentStatement: null,
         }),
       })
@@ -423,6 +433,7 @@ describe('placeOnReportService', () => {
           prisonerNumber: 'A12345',
           dateTimeOfIncident: '2020-12-10T10:00:00',
           locationId: 2,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           incidentStatement: {
             statement: 'This is a statement',
           },
@@ -436,6 +447,7 @@ describe('placeOnReportService', () => {
           id: 4,
           prisonerNumber: 'A12345',
           locationId: 2,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           dateTimeOfIncident: '2020-12-10T10:00:00',
           incidentStatement: {
             statement: 'Statement that needs to change',
@@ -451,6 +463,7 @@ describe('placeOnReportService', () => {
           id: 4,
           prisonerNumber: 'A12345',
           locationId: 2,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           dateTimeOfIncident: '2020-12-10T10:00:00',
           incidentStatement: {
             statement: 'This is a statement',
@@ -479,6 +492,7 @@ describe('placeOnReportService', () => {
         dateTime: { date: '08/11/2021', time: { hour: '10', minute: '00' } },
         dateTimeOfDiscovery: { date: '09/11/2021', time: { hour: '10', minute: '00' } },
         locationId: 1234,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         chargeNumber: null as never,
         startedByUserId: 'USER1',
       }
@@ -490,6 +504,7 @@ describe('placeOnReportService', () => {
           dateTimeOfIncident: '2021-11-08T10:00:00',
           dateTimeOfDiscovery: '2021-11-09T10:00:00',
           locationId: 1234,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         }),
       })
 
@@ -516,6 +531,7 @@ describe('placeOnReportService', () => {
         4,
         '2021-11-09T13:55:34.143Z',
         12123123,
+        '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         user,
         '2021-11-10T13:55:34.143Z'
       )
@@ -524,6 +540,7 @@ describe('placeOnReportService', () => {
         dateTimeOfIncident: '2021-11-09T13:55:34.143Z',
         dateTimeOfDiscovery: '2021-11-10T13:55:34.143Z',
         locationId: 12123123,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         removeExistingOffences: false,
       })
     })

--- a/server/services/placeOnReportService.ts
+++ b/server/services/placeOnReportService.ts
@@ -63,6 +63,7 @@ export type ExistingDraftIncidentDetails = {
   dateTime: SubmittedDateTime
   dateTimeOfDiscovery: SubmittedDateTime
   locationId: number
+  locationUuid?: string
   startedByUserId: string
   chargeNumber?: string
 }
@@ -107,6 +108,7 @@ export default class PlaceOnReportService {
   async startNewDraftAdjudication(
     dateTimeOfIncident: string,
     locationId: number,
+    locationUuid: string,
     prisonerNumber: string,
     user: User,
     gender: PrisonerGender,
@@ -119,6 +121,7 @@ export default class PlaceOnReportService {
       dateTimeOfIncident,
       agencyId: user.meta.caseLoadId,
       locationId,
+      locationUuid,
       prisonerNumber,
       dateTimeOfDiscovery,
       gender,
@@ -248,6 +251,7 @@ export default class PlaceOnReportService {
     return {
       dateTime: dateAndTimeOfIncident,
       locationId: incidentDetails.locationId,
+      locationUuid: incidentDetails.locationUuid,
       startedByUserId: response.draftAdjudication.startedByUserId,
       chargeNumber: response.draftAdjudication.chargeNumber,
       dateTimeOfDiscovery: dateAndTimeOfDiscovery,
@@ -267,6 +271,7 @@ export default class PlaceOnReportService {
     id: number,
     dateTime: string,
     location: number,
+    locationUuid: string,
     user: User,
     dateTimeOfDiscovery: string
   ): Promise<DraftAdjudicationResult> {
@@ -275,6 +280,7 @@ export default class PlaceOnReportService {
     const editedIncidentDetails = {
       dateTimeOfIncident: dateTime,
       locationId: location,
+      locationUuid,
       removeExistingOffences: false,
       dateTimeOfDiscovery,
     }

--- a/server/services/placeOnReportService.ts
+++ b/server/services/placeOnReportService.ts
@@ -62,7 +62,7 @@ export interface StaffSearchWithCurrentLocation extends StaffSearchByName {
 export type ExistingDraftIncidentDetails = {
   dateTime: SubmittedDateTime
   dateTimeOfDiscovery: SubmittedDateTime
-  locationId: number
+  locationId: number // TODO: MAP-2114: remove at a later date
   locationUuid?: string
   startedByUserId: string
   chargeNumber?: string
@@ -107,7 +107,7 @@ export default class PlaceOnReportService {
 
   async startNewDraftAdjudication(
     dateTimeOfIncident: string,
-    locationId: number,
+    locationId: number, // TODO: MAP-2114: remove at a later date
     locationUuid: string,
     prisonerNumber: string,
     user: User,
@@ -120,7 +120,7 @@ export default class PlaceOnReportService {
     const requestBody = {
       dateTimeOfIncident,
       agencyId: user.meta.caseLoadId,
-      locationId,
+      locationId, // TODO: MAP-2114: remove at a later date
       locationUuid,
       prisonerNumber,
       dateTimeOfDiscovery,
@@ -250,7 +250,7 @@ export default class PlaceOnReportService {
     const dateAndTimeOfDiscovery = await convertDateTimeStringToSubmittedDateTime(incidentDetails.dateTimeOfDiscovery)
     return {
       dateTime: dateAndTimeOfIncident,
-      locationId: incidentDetails.locationId,
+      locationId: incidentDetails.locationId, // TODO: MAP-2114: remove at a later date
       locationUuid: incidentDetails.locationUuid,
       startedByUserId: response.draftAdjudication.startedByUserId,
       chargeNumber: response.draftAdjudication.chargeNumber,
@@ -270,7 +270,7 @@ export default class PlaceOnReportService {
   async editDraftIncidentDetails(
     id: number,
     dateTime: string,
-    location: number,
+    location: number, // TODO: MAP-2114: remove at a later date
     locationUuid: string,
     user: User,
     dateTimeOfDiscovery: string

--- a/server/services/reportedAdjudicationsService.test.ts
+++ b/server/services/reportedAdjudicationsService.test.ts
@@ -381,6 +381,7 @@ describe('reportedAdjudicationsService', () => {
           dateTimeOfIncident: '2021-11-30T14:10:00',
           incidentStatement: { statement: 'Something happened' },
           locationId: 27187,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         }),
         testData.reportedAdjudication({
           chargeNumber: '1524425',
@@ -388,6 +389,7 @@ describe('reportedAdjudicationsService', () => {
           dateTimeOfIncident: '2021-11-30T14:00:00',
           incidentStatement: { statement: 'Something happened' },
           locationId: 27187,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         }),
       ]
       const batchPrisonerDetails = [
@@ -428,6 +430,7 @@ describe('reportedAdjudicationsService', () => {
           dateTimeOfIncident: '2021-11-30T14:10:00',
           incidentStatement: { statement: 'Something happened' },
           locationId: 27187,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           otherData: {
             displayName: 'Willis, Michael',
             friendlyName: 'Michael Willis',
@@ -448,6 +451,7 @@ describe('reportedAdjudicationsService', () => {
           dateTimeOfIncident: '2021-11-30T14:00:00',
           incidentStatement: { statement: 'Something happened' },
           locationId: 27187,
+          locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           otherData: {
             displayName: 'Smith, Peter',
             friendlyName: 'Peter Smith',
@@ -502,6 +506,7 @@ describe('reportedAdjudicationsService', () => {
         dateTimeOfIncident: '2021-11-16T07:21:00',
         dateTimeOfDiscovery: '2021-11-17T08:22:00',
         locationId: 25538,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         incidentStatement: {
           statement: 'Statement for a test',
         },
@@ -563,6 +568,7 @@ describe('reportedAdjudicationsService', () => {
         dateTimeOfIncident: '2021-11-16T07:21:00',
         dateTimeOfDiscovery: '2021-11-17T08:22:00',
         locationId: 25538,
+        locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
         incidentStatement: {
           statement: 'Statement for a test',
         },
@@ -975,6 +981,7 @@ describe('reportedAdjudicationsService', () => {
             dateTimeOfHearing: '2023-06-23T18:00:00',
             id: 101,
             locationId: 'location-id',
+            locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
             locationName: 'Moorland (HMP & YOI)',
             oicHearingType: OicHearingType.INAD_ADULT,
             outcome: {
@@ -1014,6 +1021,7 @@ describe('reportedAdjudicationsService', () => {
             outcome: hearingOutcome,
             oicHearingType: OicHearingType.INAD_ADULT,
             locationId: 25538,
+            locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
           }),
 
           outcome: {
@@ -1036,6 +1044,7 @@ describe('reportedAdjudicationsService', () => {
             dateTimeOfHearing: '2023-06-23T18:00:00',
             id: 101,
             locationId: 'location-id',
+            locationUuid: '0194ac90-2def-7c63-9f46-b3ccc911fdff',
             locationName: 'Houseblock 1, Moorland (HMP & YOI)',
             oicHearingType: OicHearingType.INAD_ADULT,
             outcome: {

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -925,7 +925,7 @@ export default class ReportedAdjudicationsService {
 
   async scheduleHearing(
     chargeNumber: string,
-    locationId: number,
+    locationId: number, // TODO: MAP-2114: remove at a later date
     locationUuid: string,
     dateTimeOfHearing: string,
     oicHearingType: string,
@@ -942,7 +942,7 @@ export default class ReportedAdjudicationsService {
 
   async rescheduleHearing(
     chargeNumber: string,
-    locationId: number,
+    locationId: number, // TODO: MAP-2114: remove at a later date
     locationUuid: string,
     dateTimeOfHearing: string,
     oicHearingType: string,

--- a/server/services/reportedAdjudicationsService.ts
+++ b/server/services/reportedAdjudicationsService.ts
@@ -926,12 +926,14 @@ export default class ReportedAdjudicationsService {
   async scheduleHearing(
     chargeNumber: string,
     locationId: number,
+    locationUuid: string,
     dateTimeOfHearing: string,
     oicHearingType: string,
     user: User
   ) {
     const dataToSend = {
       locationId,
+      locationUuid,
       dateTimeOfHearing,
       oicHearingType,
     }
@@ -941,12 +943,14 @@ export default class ReportedAdjudicationsService {
   async rescheduleHearing(
     chargeNumber: string,
     locationId: number,
+    locationUuid: string,
     dateTimeOfHearing: string,
     oicHearingType: string,
     user: User
   ) {
     const dataToSend = {
       locationId,
+      locationUuid,
       dateTimeOfHearing,
       oicHearingType,
     }


### PR DESCRIPTION
Adding UUID parameter for all calls to adjudications API. Both` locationId `and `locationUUID` will be sent for the time being, with a plan to remove` locationId` once some other work has been completed down the line. 