### PR TITLE
MAP-2119: Fix for when editing an existing hearing with no UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ NOMIS_USER_API_URL=https://nomis-user-dev.aks-dev-1.studio-hosting.service.justi
 FRONTEND_COMPONENT_API_URL=https://frontend-components-dev.hmpps.service.justice.gov.uk
 DATA_INSIGHTS_API_URL=https://adjudications-insights-api-dev.hmpps.service.justice.gov.uk
 ENVIRONMENT_NAME=DEV
+REDIS_HOST=localhost
 ```
 
 To start the main services excluding the manage adjudications app:

--- a/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingPage.ts
+++ b/server/routes/adjudicationForReport/scheduleHearing/scheduleHearingPage.ts
@@ -150,11 +150,10 @@ export default class scheduleHearingRoutes {
     const { reportedAdjudication } = adjudication
     const [hearingToRender] = reportedAdjudication.hearings.filter(hearing => hearing.id === hearingId)
     const locationId = await this.locationService.getCorrespondingDpsLocationId(hearingToRender.locationId, user)
-    const locationUuid = await this.locationService.getIncidentLocation(hearingToRender.locationUuid, user)
     return {
       hearingDate: convertDateTimeStringToSubmittedDateTime(hearingToRender.dateTimeOfHearing),
       locationId, // TODO: MAP-2114: remove at a later date
-      locationUuid,
+      locationUuid: locationId,
       id: hearingToRender.id,
       hearingType: getRadioHearingType(hearingToRender.oicHearingType),
     }


### PR DESCRIPTION
There is an unnecessary API that will fail as the UUID is blank and prevent a change of hearing location. This can be removed.