### PR TITLE
LSM-133 - jest lint staged config

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,24 @@
+export default {
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest'],
+  },
+  collectCoverageFrom: ['server/**/*.{ts,js,jsx,mjs}'],
+  testMatch: ['<rootDir>/(server|job)/**/?(*.)(cy|test).{ts,js,jsx,mjs}'],
+  testEnvironment: 'node',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'test_results/jest/',
+      },
+    ],
+    [
+      './node_modules/jest-html-reporter',
+      {
+        outputPath: 'test_results/unit-test-reports.html',
+      },
+    ],
+  ],
+  moduleFileExtensions: ['web.js', 'js', 'json', 'node', 'ts'],
+}

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  '*.{ts,js,mjs,css}': ['prettier --write', 'eslint --fix'],
+  '*.json': ['prettier --write'],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15497,9 +15497,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -36,38 +36,6 @@
     "node": "^22",
     "npm": "^10"
   },
-  "jest": {
-    "preset": "ts-jest",
-    "collectCoverageFrom": [
-      "server/**/*.{ts,js,jsx,mjs}"
-    ],
-    "testMatch": [
-      "<rootDir>/(server|job)/**/?(*.)(spec|test).{ts,js,jsx,mjs}"
-    ],
-    "testEnvironment": "node",
-    "reporters": [
-      "default",
-      [
-        "jest-junit",
-        {
-          "outputDirectory": "test_results/jest/"
-        }
-      ],
-      [
-        "./node_modules/jest-html-reporter",
-        {
-          "outputPath": "test_results/unit-test-reports.html"
-        }
-      ]
-    ],
-    "moduleFileExtensions": [
-      "web.js",
-      "js",
-      "json",
-      "node",
-      "ts"
-    ]
-  },
   "nodemonConfig": {
     "ignore": [
       "migrations/*",
@@ -77,15 +45,6 @@
     ],
     "delay": 2500,
     "ext": "js,json,html,njk"
-  },
-  "lint-staged": {
-    "*.{ts,js,css}": [
-      "prettier --write",
-      "eslint --fix"
-    ],
-    "*.json": [
-      "prettier --write"
-    ]
   },
   "dependencies": {
     "@ministryofjustice/frontend": "^5.1.5",


### PR DESCRIPTION
Moved Jest and lint-staged configuration from `package.json` to dedicated config files (`jest.config.mjs` and `lint-staged.config.mjs`) for better maintainability.

See TypeScript Template PR [#582](https://github.com/ministryofjustice/hmpps-template-typescript/pull/582)