### PR TITLE
MAPB-229 Refactor location API endpoints to use `service` parameter and introduce utility method for fetching locations by service type.

### DIFF
--- a/integration_tests/mockApis/locationsInsidePrisonApi.ts
+++ b/integration_tests/mockApis/locationsInsidePrisonApi.ts
@@ -73,7 +73,7 @@ const stubGetLocations = ({
   stubFor({
     request: {
       method: 'GET',
-      url: `/locationsInsidePrisonApi/locations/prison/${prisonId}/non-residential-usage-type/OCCURRENCE?formatLocalName=true&sortByLocalName=true`,
+      url: `/locationsInsidePrisonApi/locations/non-residential/prison/${prisonId}/service/LOCATION_OF_INCIDENT?formatLocalName=true&sortByLocalName=true`,
     },
     response: {
       status: 200,
@@ -92,7 +92,7 @@ const stubGetAdjudicationLocations = ({
   stubFor({
     request: {
       method: 'GET',
-      url: `/locationsInsidePrisonApi/locations/prison/${prisonId}/location-type/ADJUDICATION_ROOM?formatLocalName=true&sortByLocalName=true`,
+      url: `/locationsInsidePrisonApi/locations/non-residential/prison/${prisonId}/service/HEARING_LOCATION?formatLocalName=true&sortByLocalName=true`,
     },
     response: {
       status: 200,

--- a/server/data/locationsInsidePrisonApiClient.test.ts
+++ b/server/data/locationsInsidePrisonApiClient.test.ts
@@ -23,7 +23,9 @@ describe('locationInsidePrisonApiClient', () => {
     const locations: nock.Body = []
     it('getLocations should return data from api', async () => {
       fakeLocationsInsidePrisonApi
-        .get('/locations/prison/MDI/non-residential-usage-type/OCCURRENCE?formatLocalName=true&sortByLocalName=true')
+        .get(
+          '/locations/non-residential/prison/MDI/service/LOCATION_OF_INCIDENT?formatLocalName=true&sortByLocalName=true',
+        )
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, locations)
 
@@ -44,7 +46,7 @@ describe('locationInsidePrisonApiClient', () => {
 
     it('getAdjudicationLocations should return data from api', async () => {
       fakeLocationsInsidePrisonApi
-        .get('/locations/prison/MDI/location-type/ADJUDICATION_ROOM?formatLocalName=true&sortByLocalName=true')
+        .get('/locations/non-residential/prison/MDI/service/HEARING_LOCATION?formatLocalName=true&sortByLocalName=true')
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, locations)
 

--- a/server/data/locationsInsidePrisonApiClient.ts
+++ b/server/data/locationsInsidePrisonApiClient.ts
@@ -10,21 +10,23 @@ export default class LocationsInsidePrisonApiClient {
     this.restClient = new RestClient('Locations inside prison API', config.apis.locationsInsidePrison, token)
   }
 
-  async getLocations(prisonId: string): Promise<LocationsApiLocation[]> {
-    return this.restClient.get({
-      path: `/locations/prison/${prisonId}/non-residential-usage-type/OCCURRENCE?formatLocalName=true&sortByLocalName=true`,
-    })
-  }
-
   async getLocation(id: string): Promise<LocationsApiLocation> {
     return this.restClient.get({
       path: `/locations/${id}?formatLocalName=true`,
     })
   }
 
+  async getLocations(prisonId: string): Promise<LocationsApiLocation[]> {
+    return this.getLocationsByServiceType(prisonId, 'LOCATION_OF_INCIDENT')
+  }
+
   async getAdjudicationLocations(prisonId: string): Promise<LocationsApiLocation[]> {
+    return this.getLocationsByServiceType(prisonId, 'HEARING_LOCATION')
+  }
+
+  private getLocationsByServiceType(prisonId: string, serviceType: string): Promise<LocationsApiLocation[]> {
     return this.restClient.get({
-      path: `/locations/prison/${prisonId}/location-type/ADJUDICATION_ROOM?formatLocalName=true&sortByLocalName=true`,
+      path: `/locations/non-residential/prison/${prisonId}/service/${serviceType}?formatLocalName=true&sortByLocalName=true`,
     })
   }
 }

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -40,7 +40,7 @@ export default class LocationService {
   async getIncidentLocations(agencyId: AgencyId, user: User): Promise<IncidentLocation[]> {
     const token = await this.hmppsAuthClient.getSystemClientToken(user.username)
     const locations = await new LocationsInsidePrisonApiClient(token).getLocations(agencyId)
-    // mapping the reponse from locationsApi with that previosuly received from prisonApi
+    // mapping the response from locationsApi with that previously received from prisonApi
     const incidentLocations = locations.map(loc => ({
       locationId: loc.id, // TODO: MAP-2114: This is currently the Uuid - remove at a later date
       locationUuid: loc.id,


### PR DESCRIPTION
Refactor location API endpoints to introduce a `service` parameter. Added a utility method to fetch locations based on service type for improved modularity and code reuse.