### PR TITLE
LSM-445 - Maintenance Mode fix

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -53,7 +53,7 @@ export default function createApp(services: Services): express.Application {
 
   if (config.maintenanceModeFlag === 'true') {
     app.use('/', maintenanceRoutes(maintenancePageRouter(services.userService)))
-    app.all('*', (req, res) => {
+    app.use((req, res) => {
       res.redirect('/')
     })
   } else {
@@ -63,6 +63,7 @@ export default function createApp(services: Services): express.Application {
       res.redirect('/')
     })
   }
+
   app.get('/back-to-start', async (req, res) => {
     const { journeyStartUrl = '/' } = req.session
     delete req.session.journeyStartUrl

--- a/server/middleware/fetchFrontendComponentMiddleware.ts
+++ b/server/middleware/fetchFrontendComponentMiddleware.ts
@@ -10,6 +10,7 @@ export default function getFrontendComponents({ frontendComponentService }: Serv
         ['header', 'footer', 'meta'],
         user.token,
       )
+      logger.info('META:', meta)
       res.locals.userMetadata = meta.activeCaseLoad
       res.locals.feComponents = {
         header: header.html,

--- a/server/middleware/fetchFrontendComponentMiddleware.ts
+++ b/server/middleware/fetchFrontendComponentMiddleware.ts
@@ -10,7 +10,6 @@ export default function getFrontendComponents({ frontendComponentService }: Serv
         ['header', 'footer', 'meta'],
         user.token,
       )
-      logger.info('META:', meta)
       res.locals.userMetadata = meta.activeCaseLoad
       res.locals.feComponents = {
         header: header.html,

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -8,7 +8,8 @@ export default function populateCurrentUser(userService: UserService): RequestHa
       if (res.locals.user) {
         const user = res.locals.user && (await userService.getUserWithSession(req, res.locals.user.token))
         if (user) {
-          res.locals.user = { ...user, ...res.locals.user, meta: { ...res.locals.userMetadata } }
+          const activeCaseLoad = res.locals.userMetadata ?? user.activeCaseLoad
+          res.locals.user = { ...user, ...res.locals.user, meta: { ...activeCaseLoad } }
         } else {
           logger.info('No user available')
         }

--- a/server/views/pages/maintenancePage.njk
+++ b/server/views/pages/maintenancePage.njk
@@ -16,7 +16,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">This service is currently unavailable</h1>
         <p class="govuk-body">
-          You'll be able to use the Adjudications service on DPS again from [6pm on Thursday, 1 December 2022].
+          You'll be able to use the Adjudications service on DPS again from [7pm on Thursday, 30 May 2026].
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fix active caseload fallback and maintenance redirect

Use the session user’s active caseload when frontend component metadata is unavailable, preventing downstream API calls from missing the Active-Caseload header.

Replace the maintenance mode wildcard route with pathless middleware so the redirect works with Express 5 routing.