### PR TITLE
Removed duplicated request

### DIFF
--- a/server/routes/reviewerEditOffenceWarning/reviewerEditOffenceWarning.ts
+++ b/server/routes/reviewerEditOffenceWarning/reviewerEditOffenceWarning.ts
@@ -1,9 +1,9 @@
-import { Request, Response } from 'express'
-import DecisionTreeService from '../../services/decisionTreeService'
-import UserService from '../../services/userService'
+import type { Request, Response } from 'express'
+import type DecisionTreeService from '../../services/decisionTreeService'
+import type UserService from '../../services/userService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import { hasAnyRole } from '../../utils/utils'
-import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
+import type ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 
 export default class ReviewerEditOffenceWarningRoute {
   constructor(

--- a/server/routes/reviewerEditOffenceWarning/reviewerEditOffenceWarning.ts
+++ b/server/routes/reviewerEditOffenceWarning/reviewerEditOffenceWarning.ts
@@ -21,14 +21,12 @@ export default class ReviewerEditOffenceWarningRoute {
       return res.render('pages/notFound.njk', { url: req.headers.referer || adjudicationUrls.homepage.root })
     }
 
-    const [newDraftAdjudicationId, reportedAdjudicationResult, incidentData] = await Promise.all([
+    const [newDraftAdjudicationId, incidentData] = await Promise.all([
       this.reportedAdjudicationsService.createDraftFromCompleteAdjudication(user, chargeNumber),
-      this.reportedAdjudicationsService.getReportedAdjudicationDetails(chargeNumber, user),
       this.decisionTreeService.reportedAdjudicationIncidentData(chargeNumber, user),
     ])
 
-    const { reportedAdjudication } = reportedAdjudicationResult
-    const { prisoner, associatedPrisoner } = incidentData
+    const { prisoner, associatedPrisoner, reportedAdjudication } = incidentData
 
     const offence = await this.decisionTreeService.getAdjudicationOffences(
       reportedAdjudication.offenceDetails,

--- a/server/services/decisionTreeService.ts
+++ b/server/services/decisionTreeService.ts
@@ -26,7 +26,7 @@ export default class DecisionTreeService {
   constructor(
     private readonly placeOnReportService: PlaceOnReportService,
     private readonly userService: UserService,
-    private readonly reportedAdjudicationService: ReportedAdjudicationsService,
+    private readonly reportedAdjudicationsService: ReportedAdjudicationsService,
     private readonly decisionTree: Question,
     private readonly additionalQuestions: Question[],
   ) {}
@@ -58,7 +58,7 @@ export default class DecisionTreeService {
   }
 
   async reportedAdjudicationIncidentData(chargeNumber: string, user: User) {
-    const { reportedAdjudication } = await this.reportedAdjudicationService.getReportedAdjudicationDetails(
+    const { reportedAdjudication } = await this.reportedAdjudicationsService.getReportedAdjudicationDetails(
       chargeNumber,
       user,
     )

--- a/server/views/macros/offenceQAndASummaryList.njk
+++ b/server/views/macros/offenceQAndASummaryList.njk
@@ -25,13 +25,14 @@
 
     {# Add questions and answers to table rows #}
     {% for questionAndAnswer in offence.questionsAndAnswers %}
-        {% set value = {text: questionAndAnswer.answer} %}
         {% set rows = (rows.push(
         {
             key: {
                 text: questionAndAnswer.question
             },
-            value: value
+            value: {
+                text: questionAndAnswer.answer
+            }
         }
         ), rows) %}
     {% endfor %}


### PR DESCRIPTION
The `reviewerEditOffenceWarning` request handler was making the same request to get the information about the Adjudication twice:
- [in the request handler](https://github.com/ministryofjustice/hmpps-manage-adjudications/blob/2c3036e1d36c672d34792c9fdf202a2da4e7d995/server/routes/reviewerEditOffenceWarning/reviewerEditOffenceWarning.ts#L26) itself
- [in the `DecisionTreeService`](https://github.com/ministryofjustice/hmpps-manage-adjudications/blob/2c3036e1d36c672d34792c9fdf202a2da4e7d995/server/services/decisionTreeService.ts#L61-L63)

Assuming this `GET` request has no side effects we can avoid the duplicated request, as the adjudication data is returned by the `reportedAdjudicationIncidentData()` method anyway (it's probably not an heavy HTTP request but every little helps)

Also:
- renamed `reportedAdjudicationService` (singular) instance property to `reportedAdjudicationsService` (plural) for consistency, every other place uses the plural form and it was surprising.
- tweaked `offenceQAndASummaryList()` Nunjucks macro to remove unnecessary `value` variable: It reads better without the layer of indirection and it makes the relation between key/question and value/answer more obvious
- changed type imports in `reviewerEditOffenceWarning` request handler to be type-only imports