### PR TITLE
IR-1715 Prevent selecting a consecutive punishment that creates a loop

### DIFF
--- a/integration_tests/integration/awardPunishmentsStartAndEdit.cy.ts
+++ b/integration_tests/integration/awardPunishmentsStartAndEdit.cy.ts
@@ -201,7 +201,7 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
       chargeNumber: 101,
       response: [
         {
-          chargeNumber: 90,
+          chargeNumber: '90',
           chargeProvedDate: '2023-06-21',
           punishment: {
             id: 70,
@@ -212,7 +212,7 @@ context('e2e tests to create and edit punishments and schedules with redis', () 
           },
         },
         {
-          chargeNumber: 95,
+          chargeNumber: '95',
           chargeProvedDate: '2023-06-15',
           punishment: {
             type: PunishmentType.PROSPECTIVE_DAYS,

--- a/integration_tests/integration/whichPunishmentConsecutiveTo.cy.ts
+++ b/integration_tests/integration/whichPunishmentConsecutiveTo.cy.ts
@@ -34,7 +34,7 @@ context('which punishment will it be consecutive to page', () => {
       chargeNumber: '100',
       response: [
         {
-          chargeNumber: 90,
+          chargeNumber: '90',
           chargeProvedDate: '2023-06-21',
           punishment: {
             id: 70,
@@ -45,7 +45,7 @@ context('which punishment will it be consecutive to page', () => {
           },
         },
         {
-          chargeNumber: 95,
+          chargeNumber: '95',
           chargeProvedDate: '2023-06-15',
           punishment: {
             type: PunishmentType.ADDITIONAL_DAYS,

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveTo.test.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveTo.test.ts
@@ -91,6 +91,32 @@ describe('GET', () => {
   })
 })
 
+describe('GET', () => {
+  it('should not show a charge that is already consecutive to this charge (would create a loop)', () => {
+    punishmentsService.getPossibleConsecutivePunishments.mockResolvedValue([
+      {
+        chargeNumber: '101',
+        chargeProvedDate: '2023-07-18',
+        punishment: {
+          id: 1,
+          type: PunishmentType.ADDITIONAL_DAYS,
+          rehabilitativeActivities: [] as RehabilitativeActivity[],
+          schedule: { duration: 5 },
+          // already consecutive back to charge 100 - selecting it would create a loop
+          consecutiveChargeNumber: '100',
+        },
+      },
+    ])
+    return request(app)
+      .get(`${adjudicationUrls.whichPunishmentIsItConsecutiveTo.urls.start('100')}?punishmentType=ADDITIONAL_DAYS`)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('There are no existing punishments to select.')
+        expect(res.text).not.toContain('consecutive-report-101')
+      })
+  })
+})
+
 describe('POST', () => {
   it('should add punishment to session with consecutive punishment report number present', () => {
     return request(app)
@@ -116,6 +142,37 @@ describe('POST', () => {
           },
           '100',
         )
+      })
+  })
+
+  it('should reject a selection that would create a consecutive loop and not save it', () => {
+    punishmentsService.getPossibleConsecutivePunishments.mockResolvedValue([
+      {
+        chargeNumber: '101',
+        chargeProvedDate: '2023-07-18',
+        punishment: {
+          id: 1,
+          type: PunishmentType.ADDITIONAL_DAYS,
+          rehabilitativeActivities: [] as RehabilitativeActivity[],
+          schedule: { duration: 5 },
+          consecutiveChargeNumber: '100',
+        },
+      },
+    ])
+    return request(app)
+      .post(
+        `${adjudicationUrls.whichPunishmentIsItConsecutiveTo.urls.start(
+          '100',
+        )}?punishmentType=ADDITIONAL_DAYS&duration=5`,
+      )
+      .send({
+        select: 'consecutive-report-101',
+      })
+      .expect(res => {
+        expect(res.text).toContain('You cannot select this punishment because it is already consecutive to this charge')
+      })
+      .then(() => {
+        expect(punishmentsService.addSessionPunishment).not.toHaveBeenCalled()
       })
   })
 })

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveTo.test.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveTo.test.ts
@@ -92,21 +92,9 @@ describe('GET', () => {
 })
 
 describe('GET', () => {
-  it('should not show a charge that is already consecutive to this charge (would create a loop)', () => {
-    punishmentsService.getPossibleConsecutivePunishments.mockResolvedValue([
-      {
-        chargeNumber: '101',
-        chargeProvedDate: '2023-07-18',
-        punishment: {
-          id: 1,
-          type: PunishmentType.ADDITIONAL_DAYS,
-          rehabilitativeActivities: [] as RehabilitativeActivity[],
-          schedule: { duration: 5 },
-          // already consecutive back to charge 100 - selecting it would create a loop
-          consecutiveChargeNumber: '100',
-        },
-      },
-    ])
+  it('should show no punishments when the service has filtered out all loop candidates', () => {
+    // the service pre-filters loop candidates, so it returns an empty list here
+    punishmentsService.getPossibleConsecutivePunishments.mockResolvedValue([])
     return request(app)
       .get(`${adjudicationUrls.whichPunishmentIsItConsecutiveTo.urls.start('100')}?punishmentType=ADDITIONAL_DAYS`)
       .expect('Content-Type', /html/)
@@ -146,19 +134,8 @@ describe('POST', () => {
   })
 
   it('should reject a selection that would create a consecutive loop and not save it', () => {
-    punishmentsService.getPossibleConsecutivePunishments.mockResolvedValue([
-      {
-        chargeNumber: '101',
-        chargeProvedDate: '2023-07-18',
-        punishment: {
-          id: 1,
-          type: PunishmentType.ADDITIONAL_DAYS,
-          rehabilitativeActivities: [] as RehabilitativeActivity[],
-          schedule: { duration: 5 },
-          consecutiveChargeNumber: '100',
-        },
-      },
-    ])
+    // the service pre-filters loop candidates; submitting one that bypasses the UI hits an empty list
+    punishmentsService.getPossibleConsecutivePunishments.mockResolvedValue([])
     return request(app)
       .post(
         `${adjudicationUrls.whichPunishmentIsItConsecutiveTo.urls.start(

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToPage.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToPage.ts
@@ -5,6 +5,9 @@ import { hasAnyRole } from '../../../../utils/utils'
 import adjudicationUrls from '../../../../utils/urlGenerator'
 import PunishmentsService from '../../../../services/punishmentsService'
 import { PrivilegeType, PunishmentType, RehabilitativeActivity } from '../../../../data/PunishmentResult'
+import { FormError } from '../../../../@types/template'
+import { ConsecutiveAdditionalDaysReport } from '../../../../data/manageAdjudicationsUserTokensClient'
+import validateForm from './whichPunishmentConsecutiveToValidation'
 
 export enum PageRequestType {
   CREATION,
@@ -33,13 +36,19 @@ export default class WhichPunishmentConsecutiveToPage {
   view = async (req: Request, res: Response): Promise<void> => {
     const { user } = res.locals
     const userRoles = await this.userService.getUserRoles(user.token)
-    const { chargeNumber } = req.params
-    const { punishmentType } = req.query
-    const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
 
     if (!hasAnyRole(['ADJUDICATIONS_REVIEWER'], userRoles)) {
       return res.render('pages/notFound.njk', { url: req.headers.referer || adjudicationUrls.homepage.root })
     }
+
+    return this.renderView(req, res, [])
+  }
+
+  private renderView = async (req: Request, res: Response, errors: FormError[]): Promise<void> => {
+    const { user } = res.locals
+    const { chargeNumber } = req.params
+    const { punishmentType } = req.query
+    const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
 
     const possibleConsecutivePunishments = await this.punishmentsService.getPossibleConsecutivePunishments(
       chargeNumber,
@@ -49,11 +58,16 @@ export default class WhichPunishmentConsecutiveToPage {
 
     return res.render(`pages/whichPunishmentConsecutiveTo.njk`, {
       cancelHref: adjudicationUrls.awardPunishments.urls.modified(chargeNumber),
-      possibleConsecutivePunishments,
+      // hide any charge already consecutive to this one - selecting it would create a loop
+      possibleConsecutivePunishments: possibleConsecutivePunishments.filter(
+        report => report.punishment.consecutiveChargeNumber !== chargeNumber,
+      ),
+      errors,
     })
   }
 
   submit = async (req: Request, res: Response): Promise<void> => {
+    const { user } = res.locals
     const { chargeNumber } = req.params
     const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, duration } = req.query
     const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
@@ -61,6 +75,17 @@ export default class WhichPunishmentConsecutiveToPage {
 
     // We're grabbing the value of the button clicked, which has `consecutive-report-` before the charge number, so we need to strip that out first
     const chargeNumberOfSelectedPunishment = select.replace('consecutive-report-', '') || null
+
+    // defence-in-depth: reject a selection that would make the two charges mutually consecutive
+    const possibleConsecutivePunishments: ConsecutiveAdditionalDaysReport[] =
+      await this.punishmentsService.getPossibleConsecutivePunishments(chargeNumber, type, user)
+    const error = validateForm({
+      chargeNumber,
+      selectedChargeNumber: chargeNumberOfSelectedPunishment,
+      possibleConsecutivePunishments,
+    })
+    if (error) return this.renderView(req, res, [error])
+
     try {
       const punishmentData = {
         type,

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToPage.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToPage.ts
@@ -6,7 +6,6 @@ import adjudicationUrls from '../../../../utils/urlGenerator'
 import PunishmentsService from '../../../../services/punishmentsService'
 import { PrivilegeType, PunishmentType, RehabilitativeActivity } from '../../../../data/PunishmentResult'
 import { FormError } from '../../../../@types/template'
-import { ConsecutiveAdditionalDaysReport } from '../../../../data/manageAdjudicationsUserTokensClient'
 import validateForm from './whichPunishmentConsecutiveToValidation'
 
 export enum PageRequestType {
@@ -58,10 +57,7 @@ export default class WhichPunishmentConsecutiveToPage {
 
     return res.render(`pages/whichPunishmentConsecutiveTo.njk`, {
       cancelHref: adjudicationUrls.awardPunishments.urls.modified(chargeNumber),
-      // hide any charge already consecutive to this one - selecting it would create a loop
-      possibleConsecutivePunishments: possibleConsecutivePunishments.filter(
-        report => report.punishment.consecutiveChargeNumber !== chargeNumber,
-      ),
+      possibleConsecutivePunishments,
       errors,
     })
   }
@@ -77,10 +73,12 @@ export default class WhichPunishmentConsecutiveToPage {
     const chargeNumberOfSelectedPunishment = select.replace('consecutive-report-', '') || null
 
     // defence-in-depth: reject a selection that would make the two charges mutually consecutive
-    const possibleConsecutivePunishments: ConsecutiveAdditionalDaysReport[] =
-      await this.punishmentsService.getPossibleConsecutivePunishments(chargeNumber, type, user)
-    const error = validateForm({
+    const possibleConsecutivePunishments = await this.punishmentsService.getPossibleConsecutivePunishments(
       chargeNumber,
+      type,
+      user,
+    )
+    const error = validateForm({
       selectedChargeNumber: chargeNumberOfSelectedPunishment,
       possibleConsecutivePunishments,
     })

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.test.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.test.ts
@@ -16,27 +16,23 @@ const buildReport = (chargeNumber: string, consecutiveChargeNumber?: string): Co
 
 describe('whichPunishmentConsecutiveToValidation', () => {
   it('returns null when nothing is selected', () => {
-    expect(
-      validateForm({ chargeNumber: '100', selectedChargeNumber: null, possibleConsecutivePunishments: [] }),
-    ).toBeNull()
+    expect(validateForm({ selectedChargeNumber: null, possibleConsecutivePunishments: [] })).toBeNull()
   })
 
-  it('returns null when the selected charge is not consecutive back to this charge', () => {
+  it('returns null when the selected charge is present in the valid list', () => {
     expect(
       validateForm({
-        chargeNumber: '100',
         selectedChargeNumber: '101',
         possibleConsecutivePunishments: [buildReport('101', '99')],
       }),
     ).toBeNull()
   })
 
-  it('returns an error when the selected charge is already consecutive to this charge (loop)', () => {
+  it('returns an error when the selected charge is not in the valid list (loop candidates are pre-filtered by the service)', () => {
     expect(
       validateForm({
-        chargeNumber: '100',
         selectedChargeNumber: '101',
-        possibleConsecutivePunishments: [buildReport('101', '100')],
+        possibleConsecutivePunishments: [],
       }),
     ).toEqual({
       href: '#consecutive-punishments-table',

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.test.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.test.ts
@@ -1,0 +1,46 @@
+import validateForm from './whichPunishmentConsecutiveToValidation'
+import { PunishmentType, RehabilitativeActivity } from '../../../../data/PunishmentResult'
+import { ConsecutiveAdditionalDaysReport } from '../../../../data/manageAdjudicationsUserTokensClient'
+
+const buildReport = (chargeNumber: string, consecutiveChargeNumber?: string): ConsecutiveAdditionalDaysReport => ({
+  chargeNumber,
+  chargeProvedDate: '2023-07-18',
+  punishment: {
+    id: 1,
+    type: PunishmentType.ADDITIONAL_DAYS,
+    rehabilitativeActivities: [] as RehabilitativeActivity[],
+    schedule: { duration: 5 },
+    consecutiveChargeNumber,
+  },
+})
+
+describe('whichPunishmentConsecutiveToValidation', () => {
+  it('returns null when nothing is selected', () => {
+    expect(
+      validateForm({ chargeNumber: '100', selectedChargeNumber: null, possibleConsecutivePunishments: [] }),
+    ).toBeNull()
+  })
+
+  it('returns null when the selected charge is not consecutive back to this charge', () => {
+    expect(
+      validateForm({
+        chargeNumber: '100',
+        selectedChargeNumber: '101',
+        possibleConsecutivePunishments: [buildReport('101', '99')],
+      }),
+    ).toBeNull()
+  })
+
+  it('returns an error when the selected charge is already consecutive to this charge (loop)', () => {
+    expect(
+      validateForm({
+        chargeNumber: '100',
+        selectedChargeNumber: '101',
+        possibleConsecutivePunishments: [buildReport('101', '100')],
+      }),
+    ).toEqual({
+      href: '#consecutive-punishments-table',
+      text: 'You cannot select this punishment because it is already consecutive to this charge',
+    })
+  })
+})

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.ts
@@ -2,7 +2,6 @@ import { FormError } from '../../../../@types/template'
 import { ConsecutiveAdditionalDaysReport } from '../../../../data/manageAdjudicationsUserTokensClient'
 
 type WhichPunishmentConsecutiveToForm = {
-  chargeNumber: string
   selectedChargeNumber?: string
   possibleConsecutivePunishments: ConsecutiveAdditionalDaysReport[]
 }
@@ -15,16 +14,13 @@ const errors: { [key: string]: FormError } = {
 }
 
 export default function validateForm({
-  chargeNumber,
   selectedChargeNumber,
   possibleConsecutivePunishments,
 }: WhichPunishmentConsecutiveToForm): FormError | null {
   if (!selectedChargeNumber) return null
 
-  const selected = possibleConsecutivePunishments.find(report => report.chargeNumber === selectedChargeNumber)
-  if (selected && selected.punishment.consecutiveChargeNumber === chargeNumber) {
-    return errors.CONSECUTIVE_LOOP
-  }
+  const isValidSelection = possibleConsecutivePunishments.some(report => report.chargeNumber === selectedChargeNumber)
+  if (!isValidSelection) return errors.CONSECUTIVE_LOOP
 
   return null
 }

--- a/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.ts
+++ b/server/routes/punishmentsForReport/additionalDays/whichPunishmentConsecutiveTo/whichPunishmentConsecutiveToValidation.ts
@@ -1,0 +1,30 @@
+import { FormError } from '../../../../@types/template'
+import { ConsecutiveAdditionalDaysReport } from '../../../../data/manageAdjudicationsUserTokensClient'
+
+type WhichPunishmentConsecutiveToForm = {
+  chargeNumber: string
+  selectedChargeNumber?: string
+  possibleConsecutivePunishments: ConsecutiveAdditionalDaysReport[]
+}
+
+const errors: { [key: string]: FormError } = {
+  CONSECUTIVE_LOOP: {
+    href: '#consecutive-punishments-table',
+    text: 'You cannot select this punishment because it is already consecutive to this charge',
+  },
+}
+
+export default function validateForm({
+  chargeNumber,
+  selectedChargeNumber,
+  possibleConsecutivePunishments,
+}: WhichPunishmentConsecutiveToForm): FormError | null {
+  if (!selectedChargeNumber) return null
+
+  const selected = possibleConsecutivePunishments.find(report => report.chargeNumber === selectedChargeNumber)
+  if (selected && selected.punishment.consecutiveChargeNumber === chargeNumber) {
+    return errors.CONSECUTIVE_LOOP
+  }
+
+  return null
+}

--- a/server/services/punishmentsService.test.ts
+++ b/server/services/punishmentsService.test.ts
@@ -17,6 +17,7 @@ const amendPunishmentComment = jest.fn()
 const removePunishmentComment = jest.fn()
 const getPrisonerDetails = jest.fn()
 const getSuspendedPunishments = jest.fn()
+const getPossibleConsecutivePunishments = jest.fn()
 const getUserFromUsername = jest.fn()
 
 jest.mock('../data/manageAdjudicationsUserTokensClient', () => {
@@ -27,6 +28,7 @@ jest.mock('../data/manageAdjudicationsUserTokensClient', () => {
       amendPunishmentComment,
       removePunishmentComment,
       getSuspendedPunishments,
+      getPossibleConsecutivePunishments,
     }
   })
 })
@@ -352,6 +354,40 @@ describe('PunishmentsService', () => {
           time: '06:00',
         },
       ])
+    })
+  })
+
+  describe('getPossibleConsecutivePunishments', () => {
+    it('filters out entries that are already consecutive to the requested charge (would create a loop)', async () => {
+      getReportedAdjudication.mockResolvedValue({
+        reportedAdjudication: testData.reportedAdjudication({ chargeNumber: '100', prisonerNumber: 'G6123VU' }),
+      })
+      getPossibleConsecutivePunishments.mockResolvedValue([
+        {
+          chargeNumber: '101',
+          chargeProvedDate: '2023-07-18',
+          punishment: {
+            id: 1,
+            type: PunishmentType.ADDITIONAL_DAYS,
+            rehabilitativeActivities: [] as RehabilitativeActivity[],
+            schedule: { duration: 5 },
+          },
+        },
+        {
+          chargeNumber: '102',
+          chargeProvedDate: '2023-07-19',
+          punishment: {
+            id: 2,
+            type: PunishmentType.ADDITIONAL_DAYS,
+            rehabilitativeActivities: [] as RehabilitativeActivity[],
+            schedule: { duration: 3 },
+            consecutiveChargeNumber: '100',
+          },
+        },
+      ])
+      const result = await service.getPossibleConsecutivePunishments('100', PunishmentType.ADDITIONAL_DAYS, user)
+      expect(result).toHaveLength(1)
+      expect(result[0].chargeNumber).toBe('101')
     })
   })
 })

--- a/server/services/punishmentsService.ts
+++ b/server/services/punishmentsService.ts
@@ -467,11 +467,12 @@ export default class PunishmentsService {
     user: User,
   ): Promise<ConsecutiveAdditionalDaysReport[]> {
     const reportedAdjudication = await this.getReportedAdjudication(chargeNumber, user)
-    return new ManageAdjudicationsUserTokensClient(user).getPossibleConsecutivePunishments(
+    const results = await new ManageAdjudicationsUserTokensClient(user).getPossibleConsecutivePunishments(
       reportedAdjudication.prisonerNumber,
       punishmentType,
       chargeNumber,
     )
+    return results.filter(report => report.punishment.consecutiveChargeNumber !== chargeNumber)
   }
 
   async formatPunishmentComments(reportedAdjudication: ReportedAdjudication, chargeNumber: string, user: User) {

--- a/server/views/pages/whichPunishmentConsecutiveTo.njk
+++ b/server/views/pages/whichPunishmentConsecutiveTo.njk
@@ -1,6 +1,7 @@
 {% extends "../partials/layout.njk" %}
 {% from "../partials/breadCrumb.njk" import breadcrumb %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "../macros/consecutivePunishmentsTable.njk" import consecutivePunishmentsTable %}
 
 {% set title = "Which punishment will it be consecutive to?" %}
@@ -13,13 +14,23 @@
 {% endblock %}
 
 {% block content %}
+  {% if errors | length %}
+    {{ govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: errors,
+      attributes: { "data-qa": "error-summary" }
+    }) }}
+  {% endif %}
+
   <h1 class="govuk-heading-l">{{ title }}</h1>
   <div>
     <form method="POST" novalidate="novalidate" class="govuk-!-margin-top-5">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
       {% if possibleConsecutivePunishments.length %}
-        {{ consecutivePunishmentsTable(possibleConsecutivePunishments) }}
+        <div id="consecutive-punishments-table">
+          {{ consecutivePunishmentsTable(possibleConsecutivePunishments) }}
+        </div>
       {% else %}
         <p class="govuk-body" data-qa='no-data'>There are no existing punishments to select.</p>
       {% endif %}


### PR DESCRIPTION
## What

Stop users from making two charges mutually consecutive (a \"consecutive loop\") on the *\"Which punishment will it be consecutive to?\"* page.

## Why

Looped consecutive punishments break downstream services such as Calculate Release Dates. The API now rejects them with a 400, but the frontend only POSTs punishments on the final \"check punishments\" page — so without a frontend guard the user wouldn't see the error until the very end. This change prevents the user reaching that state.

## How

- Move the loop-prevention filter into \`getPossibleConsecutivePunishments()\` in \`PunishmentsService\` so all callers automatically receive a loop-safe list (addressing review feedback: no future caller can accidentally re-introduce the bug or forget to filter).
- \`validateForm\` is updated to check presence in the pre-filtered list rather than inspecting \`consecutiveChargeNumber\` on individual entries, keeping the defence-in-depth POST guard intact.
- Added \`whichPunishmentConsecutiveToValidation.ts\` plus a submit-time guard that re-renders the page with a \`govukErrorSummary\` if a looping selection is somehow forced.
- Added the error summary block to the page template.

## Tests

- Unit test in \`punishmentsService.test.ts\` covering the loop filter directly in the service.
- Route tests covering the GET filter (looping charge hidden) and the POST guard (selection rejected, nothing saved to session).
- Unit tests for the validation module.