### PR TITLE
IR-1753: Increase loss of privileges max number of days for adults (to 84)

### DIFF
--- a/.gitleaks/.gitleaksignore
+++ b/.gitleaks/.gitleaksignore
@@ -1,3 +1,9 @@
 # The Fingerprint of false positive alerts can be added here to be excluded from future scans.
+
+# `MAX_DAYS + 1` mistaken for a secret?
 server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts:token:49
 server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts:token:65
+server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts:token:138
+server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts:token:145
+server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts:token:161
+server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts:token:168

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
@@ -103,7 +103,7 @@ describe('validateForm', () => {
     })
   })
 
-  it('Valid submit has no errors - confinement type earnings for adult', () => {
+  it('Valid submit has no errors - punishment type confinement for adult', () => {
     expect(validateForm(PunishmentType.CONFINEMENT, 21, false)).toBeNull()
   })
 

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
@@ -128,7 +128,7 @@ describe('validateForm', () => {
   describe('Loss of privileges days validation', () => {
     describe('for adults', () => {
       const IS_YOI = false
-      const MAX_DAYS = 42
+      const MAX_DAYS = 84
 
       it('when valid number, has no errors', () => {
         expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS, IS_YOI, PrivilegeType.CANTEEN)).toBeNull()
@@ -137,14 +137,14 @@ describe('validateForm', () => {
       it('when days above max, returns error', () => {
         expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS + 1, IS_YOI, PrivilegeType.CANTEEN)).toEqual({
           href: '#duration',
-          text: 'Days for loss of canteen cannot be more than 42 days for an offence under Adult rules',
+          text: 'Days for loss of canteen cannot be more than 84 days for an offence under Adult rules',
         })
       })
 
       it('when days above max and privilege type is Other, error wording is generic', () => {
         expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS + 1, IS_YOI, PrivilegeType.OTHER)).toEqual({
           href: '#duration',
-          text: 'Days for loss of privilege cannot be more than 42 days for an offence under Adult rules',
+          text: 'Days for loss of privilege cannot be more than 84 days for an offence under Adult rules',
         })
       })
     })

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
@@ -1,4 +1,4 @@
-import { convertPrivilegeType, PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
+import { PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
 import validateForm from './punishmentDaysValidator'
 
 describe('validateForm', () => {
@@ -125,43 +125,51 @@ describe('validateForm', () => {
     })
   })
 
-  it('Valid submit has no errors - privilege type earnings for adult', () => {
-    expect(validateForm(PunishmentType.PRIVILEGE, 42, false, PrivilegeType.CANTEEN)).toBeNull()
-  })
+  describe('Loss of privileges days validation', () => {
+    describe('for adults', () => {
+      const IS_YOI = false
+      const MAX_DAYS = 42
 
-  it('shows error when privilege days above max for adult', () => {
-    expect(validateForm(PunishmentType.PRIVILEGE, 43, false, PrivilegeType.CANTEEN)).toEqual({
-      href: '#duration',
-      text: `Days for loss of ${convertPrivilegeType(
-        PrivilegeType.CANTEEN,
-      )} cannot be more than 42 days for an offence under Adult rules`,
+      it('when valid number, has no errors', () => {
+        expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS, IS_YOI, PrivilegeType.CANTEEN)).toBeNull()
+      })
+
+      it('when days above max, returns error', () => {
+        expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS + 1, IS_YOI, PrivilegeType.CANTEEN)).toEqual({
+          href: '#duration',
+          text: 'Days for loss of canteen cannot be more than 42 days for an offence under Adult rules',
+        })
+      })
+
+      it('when days above max and privilege type is Other, error wording is generic', () => {
+        expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS + 1, IS_YOI, PrivilegeType.OTHER)).toEqual({
+          href: '#duration',
+          text: 'Days for loss of privilege cannot be more than 42 days for an offence under Adult rules',
+        })
+      })
     })
-  })
 
-  it('shows error when privilege other days above max for adult', () => {
-    expect(validateForm(PunishmentType.PRIVILEGE, 43, false, PrivilegeType.OTHER)).toEqual({
-      href: '#duration',
-      text: `Days for loss of privilege cannot be more than 42 days for an offence under Adult rules`,
-    })
-  })
+    describe('for YOI', () => {
+      const IS_YOI = true
+      const MAX_DAYS = 21
 
-  it('shows error when privilege other days above max for adult', () => {
-    expect(validateForm(PunishmentType.PRIVILEGE, 22, true, PrivilegeType.OTHER)).toEqual({
-      href: '#duration',
-      text: `Days for loss of privilege cannot be more than 21 days for an offence under YOI rules`,
-    })
-  })
+      it('when valid number, has no errors', () => {
+        expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS, IS_YOI, PrivilegeType.CANTEEN)).toBeNull()
+      })
 
-  it('Valid submit has no errors - punishment type privilege for YOI', () => {
-    expect(validateForm(PunishmentType.PRIVILEGE, 21, true, PrivilegeType.CANTEEN)).toBeNull()
-  })
+      it('when days above max, returns error', () => {
+        expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS + 1, IS_YOI, PrivilegeType.CANTEEN)).toEqual({
+          href: '#duration',
+          text: 'Days for loss of canteen cannot be more than 21 days for an offence under YOI rules',
+        })
+      })
 
-  it('shows error when privilege days above max for YOI', () => {
-    expect(validateForm(PunishmentType.PRIVILEGE, 22, true, PrivilegeType.CANTEEN)).toEqual({
-      href: '#duration',
-      text: `Days for loss of ${convertPrivilegeType(
-        PrivilegeType.CANTEEN,
-      )} cannot be more than 21 days for an offence under YOI rules`,
+      it('when days above max and privilege type is Other, error wording is generic', () => {
+        expect(validateForm(PunishmentType.PRIVILEGE, MAX_DAYS + 1, IS_YOI, PrivilegeType.OTHER)).toEqual({
+          href: '#duration',
+          text: 'Days for loss of privilege cannot be more than 21 days for an offence under YOI rules',
+        })
+      })
     })
   })
 

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
@@ -113,18 +113,10 @@ export default function validatePunishmentDays(
 
   if (punishmentType === PunishmentType.PRIVILEGE) {
     if (isAdult && duration > 42) {
-      return formatPrivilegeErrorText(
-        privilegeType,
-        errors.PRIVILEGE_DAYS_MAX_ADULT.href,
-        errors.PRIVILEGE_DAYS_MAX_ADULT.text,
-      )
+      return formatPrivilegeErrorText(privilegeType, errors.PRIVILEGE_DAYS_MAX_ADULT)
     }
     if (isYOI && duration > 21) {
-      return formatPrivilegeErrorText(
-        privilegeType,
-        errors.PRIVILEGE_DAYS_MAX_YOI.href,
-        errors.PRIVILEGE_DAYS_MAX_YOI.text,
-      )
+      return formatPrivilegeErrorText(privilegeType, errors.PRIVILEGE_DAYS_MAX_YOI)
     }
   }
 
@@ -148,10 +140,10 @@ export default function validatePunishmentDays(
   return null
 }
 
-function formatPrivilegeErrorText(privilegeType: PrivilegeType, href: string, text: string): FormError {
+function formatPrivilegeErrorText(privilegeType: PrivilegeType, error: FormError): FormError {
   return {
-    href,
-    text: text.replace(
+    ...error,
+    text: error.text.replace(
       '[thing]',
       privilegeType === PrivilegeType.OTHER ? 'privilege' : convertPrivilegeType(privilegeType),
     ),

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
@@ -40,7 +40,7 @@ const errors: { [key: string]: FormError } = {
   },
   PRIVILEGE_DAYS_MAX_ADULT: {
     href: '#duration',
-    text: 'Days for loss of [thing] cannot be more than 42 days for an offence under Adult rules',
+    text: 'Days for loss of [thing] cannot be more than 84 days for an offence under Adult rules',
   },
   PRIVILEGE_DAYS_MAX_YOI: {
     href: '#duration',
@@ -112,7 +112,7 @@ export default function validatePunishmentDays(
   }
 
   if (punishmentType === PunishmentType.PRIVILEGE) {
-    if (isAdult && duration > 42) {
+    if (isAdult && duration > 84) {
       return formatPrivilegeErrorText(privilegeType, errors.PRIVILEGE_DAYS_MAX_ADULT)
     }
     if (isYOI && duration > 21) {


### PR DESCRIPTION
The `PunishmentType.PRIVILEGE` type is for loss of privileges like Canteen, TV, Other, etc...

**NOTE**: This is not changing the validation on `PunishmentType.EXTRA_WORK` or `PunishmentType.REMOVAL_ACTIVITY`, I asked Steve for clarification but not touching those as part of this PR. Also, the Stoppage of earnings punishment limit was already 84 days for adults so no change there neither.