### PR TITLE
IR-1780 Allow deploying a feature branch to the dev environment

### DIFF
--- a/.github/workflows/deploy_to_env.yml
+++ b/.github/workflows/deploy_to_env.yml
@@ -1,0 +1,40 @@
+name: Deploy to environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        type: choice
+        required: true
+        options:
+          - dev
+          - preprod
+          - prod
+        default: 'dev'
+      version:
+        description: version to be deployed to the environment - must already exist.
+        required: true
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  helm_lint:
+    name: helm lint
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+  deploy_env:
+    name: Deploy to environment
+    needs:
+      - helm_lint
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
+    secrets: inherit
+    with:
+      environment: ${{ inputs.environment }}
+      app_version: ${{ inputs.version }}
+      slack_notification: 'false' # if 'true', it needs a valid (NON)PROD_RELEASES_SLACK_CHANNEL variable to be set

--- a/.github/workflows/deploy_to_env.yml
+++ b/.github/workflows/deploy_to_env.yml
@@ -10,7 +10,8 @@ on:
         options:
           - dev
           - preprod
-          - prod
+          # Deploy to Production only from `main` branch, using normal process
+          # - prod
         default: 'dev'
       version:
         description: version to be deployed to the environment - must already exist.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,10 +34,10 @@ jobs:
     name: Check publish flag
     runs-on: ubuntu-latest
     outputs:
-      enabled: ${{ github.ref == 'refs/heads/main' && (inputs.push || inputs.push == null) }}
+      enabled: ${{ (github.ref == 'refs/heads/main' && (inputs.push || inputs.push == null)) || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}
     steps:
       - name: Set publish flag
-        run: echo "Publishing enabled ${{ github.ref == 'refs/heads/main' && (inputs.push || inputs.push == null) }}"
+        run: echo "Publishing enabled ${{ (github.ref == 'refs/heads/main' && (inputs.push || inputs.push == null)) || (github.event_name == 'workflow_dispatch' && inputs.push == true) }}"
   node_build:
     name: node build
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/node_build.yml@v2 # WORKFLOW_VERSION
@@ -81,7 +81,7 @@ jobs:
       sign_image: ${{ needs.check_publish.outputs.enabled == 'true' }}
   deploy_dev:
     name: Deploy to the dev environment
-    if: needs.check_publish.outputs.enabled == 'true'
+    if: github.ref == 'refs/heads/main'
     needs:
       - build
       - helm_lint
@@ -93,7 +93,7 @@ jobs:
       app_version: '${{ needs.build.outputs.app_version }}'
   deploy_preprod:
     name: Deploy to the preprod environment
-    if: needs.check_publish.outputs.enabled == 'true'
+    if: github.ref == 'refs/heads/main'
     needs:
       - build
       - helm_lint
@@ -105,6 +105,7 @@ jobs:
       app_version: '${{ needs.build.outputs.app_version }}'
   deploy_prod:
     name: Deploy to the prod environment
+    if: github.ref == 'refs/heads/main'
     needs:
       - build
       - helm_lint


### PR DESCRIPTION
## Why

We have a long-running feature branch (~2 months) that can't go live yet but needs to be deployed to **dev** for testing. The frontend pipeline previously only published a Docker image on `main` and had no manual deploy workflow, so there was no way to get a feature-branch build onto dev. (The API repo already supports this.)

## What

**`pipeline.yml`**
- `check_publish.enabled` now also turns on when the pipeline is run via **Run workflow** (`workflow_dispatch`) with `push=true` on any branch, so a feature-branch build publishes a signed, versioned image to `ghcr.io`. Normal `main` and normal (non-dispatch) feature-branch behaviour are unchanged.
- `deploy_dev` / `deploy_preprod` / `deploy_prod` are now gated on `if: github.ref == 'refs/heads/main'` instead of the publish flag. Publishing an image no longer implies a deploy — a feature-branch dispatch can never auto-deploy anywhere.

**`deploy_to_env.yml`** (new)
- Manual `workflow_dispatch` deploy mirroring the API's: pick `environment` (dev/preprod/prod) and a `version`, runs helm lint, then the shared `deploy_env.yml@v2`.

## How to use

1. Actions → **Pipeline** → *Run workflow* → select the feature branch → set `push = true`. Note the version from the `build` job's `app_version` output.
2. Actions → **Deploy to environment** → *Run workflow* → `environment = dev`, `version = <that version>`.

Note: deploying a feature branch to dev replaces what's running there; re-deploy the latest `main` version to dev when finished testing.