### PR TITLE
IR 1757 recording new visits punishment

### DIFF
--- a/integration_tests/integration/checkPunishments.cy.ts
+++ b/integration_tests/integration/checkPunishments.cy.ts
@@ -272,7 +272,7 @@ context('Check punishments', () => {
     it('can submit edited punishments', () => {
       cy.visit(adjudicationUrls.awardPunishments.urls.start('456'))
       cy.get('[data-qa="add-new-punishment-button"]').click()
-      cy.get('#punishmentType-3').click()
+      cy.get('input[name="punishmentType"][value="EARNINGS"]').check()
       cy.get('#stoppagePercentage').type('25')
       cy.get('[data-qa="punishment-submit"]').click()
 

--- a/integration_tests/integration/punishment.cy.ts
+++ b/integration_tests/integration/punishment.cy.ts
@@ -37,6 +37,7 @@ context('Add a new punishment', () => {
           chargeNumber: '101',
           prisonerNumber: 'G6123VU',
           status: ReportedAdjudicationStatus.CHARGE_PROVED,
+          isYouthOffender: true,
           hearings: [
             testData.singleHearing({
               dateTimeOfHearing: '2024-11-23T17:00:00',
@@ -67,10 +68,8 @@ context('Add a new punishment', () => {
     })
     it('should show additional days and prospective additional days radios if the hearing is IA', () => {
       cy.visit(adjudicationUrls.punishment.urls.start('101'))
-      cy.get('#punishmentType-11').should('exist')
-      cy.get('[for="punishmentType-11"]').should('include.text', 'Additional days')
-      cy.get('#punishmentType-12').should('exist')
-      cy.get('[for="punishmentType-12"]').should('include.text', 'Prospective additional days')
+      cy.get('input[name="punishmentType"][value="ADDITIONAL_DAYS"]').should('exist')
+      cy.get('input[name="punishmentType"][value="PROSPECTIVE_DAYS"]').should('exist')
     })
     it('should contain caution and damages radio buttons', () => {
       cy.visit(adjudicationUrls.punishment.urls.start('101'))
@@ -78,6 +77,21 @@ context('Add a new punishment', () => {
       cy.get('[for="punishmentType"]').should('include.text', 'Recovery of money for damages')
       cy.get('#punishmentType-2').should('exist')
       cy.get('[for="punishmentType-2"]').should('include.text', 'Caution')
+    })
+    it('shows social visits punishments and the child question for an adult adjudication', () => {
+      cy.visit(adjudicationUrls.punishment.urls.start('100'))
+
+      cy.get('input[value="LOSS_OF_SOCIAL_VISITS"]').check()
+      cy.get('label[for="lossHasChildUnder18"]').should('be.visible')
+      cy.contains('Does the prisoner have any children under 18?').should('be.visible')
+
+      cy.get('input[value="RESTRICTION_OF_SOCIAL_VISITS"]').check()
+      cy.get('label[for="restrictionHasChildUnder18"]').should('be.visible')
+    })
+    it('does not show social visits punishments for a YOI adjudication', () => {
+      cy.visit(adjudicationUrls.punishment.urls.start('101'))
+      cy.get('input[value="LOSS_OF_SOCIAL_VISITS"]').should('not.exist')
+      cy.get('input[value="RESTRICTION_OF_SOCIAL_VISITS"]').should('not.exist')
     })
   })
 
@@ -137,6 +151,14 @@ context('Add a new punishment', () => {
           expect($error.get(0).innerText).to.contain('Enter the percentage of earnings to be stopped')
         })
     })
+    it('should error when the child question is not answered', () => {
+      cy.visit(adjudicationUrls.punishment.urls.start('100'))
+      const punishmentPage = Page.verifyOnPage(PunishmentPage)
+      punishmentPage.punishment().find('input[value="LOSS_OF_SOCIAL_VISITS"]').check()
+      punishmentPage.submitButton().click()
+
+      punishmentPage.errorSummary().should('contain.text', 'Select whether the prisoner has any children under 18')
+    })
   })
 
   describe('Submit', () => {
@@ -191,6 +213,21 @@ context('Add a new punishment', () => {
 
       cy.location().should(loc => {
         expect(loc.pathname).to.eq(adjudicationUrls.punishmentNumberOfDays.urls.start('100'))
+      })
+    })
+
+    it('should carry the child answer when adding a social visits punishment', () => {
+      cy.visit(adjudicationUrls.punishment.urls.start('100'))
+      const punishmentPage = Page.verifyOnPage(PunishmentPage)
+
+      punishmentPage.punishment().find('input[value="RESTRICTION_OF_SOCIAL_VISITS"]').check()
+      cy.get('input[name="restrictionHasChildUnder18"][value="false"]').check()
+      punishmentPage.submitButton().click()
+
+      cy.location().should(loc => {
+        expect(loc.pathname).to.eq(adjudicationUrls.punishmentNumberOfDays.urls.start('100'))
+        expect(loc.search).to.contain('punishmentType=RESTRICTION_OF_SOCIAL_VISITS')
+        expect(loc.search).to.contain('hasChildUnder18=false')
       })
     })
   })

--- a/integration_tests/integration/reasonForChangePunishment.cy.ts
+++ b/integration_tests/integration/reasonForChangePunishment.cy.ts
@@ -73,7 +73,7 @@ context('What is the reason for this change', () => {
       // Need to set up a punishment in the session first
       cy.visit(adjudicationUrls.awardPunishments.urls.modified('100'))
       cy.get('[data-qa="add-new-punishment-button"]').click()
-      cy.get('#punishmentType-4').click()
+      cy.get('input[name="punishmentType"][value="EARNINGS"]').check()
       cy.get('#stoppagePercentage').type('25')
       cy.get('[data-qa="punishment-submit"]').click()
 

--- a/server/data/PunishmentResult.ts
+++ b/server/data/PunishmentResult.ts
@@ -11,6 +11,8 @@ export enum PunishmentType {
   CAUTION = 'CAUTION',
   DAMAGES_OWED = 'DAMAGES_OWED',
   PAYBACK = 'PAYBACK',
+  RESTRICTION_OF_SOCIAL_VISITS = 'RESTRICTION_OF_SOCIAL_VISITS',
+  LOSS_OF_SOCIAL_VISITS = 'LOSS_OF_SOCIAL_VISITS',
 }
 
 export enum PrivilegeType {
@@ -65,6 +67,7 @@ export type PunishmentData = {
   consecutiveChargeNumber?: string
   consecutiveReportAvailable?: boolean
   damagesOwedAmount?: number
+  hasChildUnder18?: boolean
   canRemove?: boolean
   canEdit?: boolean
   rehabilitativeActivities: RehabilitativeActivity[]
@@ -95,6 +98,7 @@ export type PunishmentDataWithSchedule = {
   consecutiveChargeNumber?: string
   consecutiveReportAvailable?: boolean
   damagesOwedAmount?: number
+  hasChildUnder18?: boolean
   canRemove?: boolean
   canEdit?: boolean
   rehabilitativeActivities: RehabilitativeActivity[]
@@ -279,6 +283,10 @@ export function convertPunishmentType(
       return 'Recovery of money for damages'
     case PunishmentType.PAYBACK:
       return 'Payback punishment'
+    case PunishmentType.RESTRICTION_OF_SOCIAL_VISITS:
+      return 'Restriction of social visits'
+    case PunishmentType.LOSS_OF_SOCIAL_VISITS:
+      return 'Loss of social visits'
     default:
       return null
   }
@@ -297,6 +305,7 @@ export function flattenPunishment(punishment: PunishmentDataWithSchedule): Punis
     consecutiveChargeNumber,
     consecutiveReportAvailable,
     damagesOwedAmount,
+    hasChildUnder18,
     canRemove,
     canEdit,
     rehabilitativeActivities,
@@ -323,11 +332,22 @@ export function flattenPunishment(punishment: PunishmentDataWithSchedule): Punis
     ...(consecutiveChargeNumber && { consecutiveChargeNumber }),
     ...(consecutiveReportAvailable && { consecutiveReportAvailable }),
     ...(damagesOwedAmount && { damagesOwedAmount }),
+    ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
     rehabilitativeActivities,
     rehabilitativeActivitiesCompleted,
     rehabilitativeActivitiesNotCompletedOutcome,
     previousSuspendedUntilDate,
   }
+}
+
+export function isSocialVisitsPunishment(type?: PunishmentType): boolean {
+  return [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, PunishmentType.LOSS_OF_SOCIAL_VISITS].includes(type)
+}
+
+export function parseHasChildUnder18(value: unknown): boolean | undefined {
+  if (value === true || value === 'true') return true
+  if (value === false || value === 'false') return false
+  return undefined
 }
 
 export function flattenPunishments(punishments: PunishmentDataWithSchedule[]): PunishmentData[] {

--- a/server/routes/punishmentsForReport/punishment/punishment.test.ts
+++ b/server/routes/punishmentsForReport/punishment/punishment.test.ts
@@ -5,32 +5,22 @@ import adjudicationUrls from '../../../utils/urlGenerator'
 import UserService from '../../../services/userService'
 import PunishmentsService from '../../../services/punishmentsService'
 import { PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
-import ReportedAdjudicationsService from '../../../services/reportedAdjudicationsService'
-import TestData from '../../testutils/testData'
 
 jest.mock('../../../services/userService')
 jest.mock('../../../services/punishmentsService')
-jest.mock('../../../services/reportedAdjudicationsService')
-const testData = new TestData()
 
 const userService = new UserService(null, null) as jest.Mocked<UserService>
 const punishmentsService = new PunishmentsService(null, null) as jest.Mocked<PunishmentsService>
-const reportedAdjudicationsService = new ReportedAdjudicationsService(
-  null,
-  null,
-  null,
-  null,
-  null,
-) as jest.Mocked<ReportedAdjudicationsService>
 
 let app: Express
 
 beforeEach(() => {
-  app = appWithAllRoutes({ production: false }, { userService, punishmentsService, reportedAdjudicationsService }, {})
+  app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
   userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
-  reportedAdjudicationsService.getLatestHearing.mockResolvedValue(
-    testData.singleHearing({ id: 100, dateTimeOfHearing: '2022-11-03T11:00:00' }),
-  )
+  punishmentsService.getPunishmentAvailability.mockResolvedValue({
+    isIndependentAdjudicatorHearing: false,
+    socialVisitsAvailable: true,
+  })
 })
 
 afterEach(() => {
@@ -59,6 +49,24 @@ describe('GET /punishment', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Add a punishment or money for damages')
+        expect(res.text).toContain('Loss of social visits')
+        expect(res.text).toContain('Restriction of social visits')
+        expect(res.text).toContain('Does the prisoner have any children under 18?')
+      })
+  })
+
+  it('does not offer social visits punishments for a YOI adjudication', async () => {
+    punishmentsService.getPunishmentAvailability.mockResolvedValue({
+      isIndependentAdjudicatorHearing: false,
+      socialVisitsAvailable: false,
+    })
+
+    await request(app)
+      .get(adjudicationUrls.punishment.urls.start('100'))
+      .expect(200)
+      .expect(res => {
+        expect(res.text).not.toContain('Loss of social visits')
+        expect(res.text).not.toContain('Restriction of social visits')
       })
   })
 })
@@ -79,5 +87,31 @@ describe('POST /punishment', () => {
           '100',
         )}?punishmentType=PRIVILEGE&privilegeType=OTHER&otherPrivilege=nintendo%20switch&stoppagePercentage=`,
       )
+  })
+
+  it.each([
+    [PunishmentType.LOSS_OF_SOCIAL_VISITS, 'lossHasChildUnder18', 'true'],
+    [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, 'restrictionHasChildUnder18', 'false'],
+  ])('carries the child answer into the schedule for %s', (punishmentType, childField, hasChildUnder18) => {
+    return request(app)
+      .post(adjudicationUrls.punishment.urls.start('100'))
+      .send({ punishmentType, [childField]: hasChildUnder18 })
+      .expect(302)
+      .expect(
+        'Location',
+        `${adjudicationUrls.punishmentNumberOfDays.urls.start(
+          '100',
+        )}?punishmentType=${punishmentType}&hasChildUnder18=${hasChildUnder18}`,
+      )
+  })
+
+  it('shows an error when the child question is not answered', () => {
+    return request(app)
+      .post(adjudicationUrls.punishment.urls.start('100'))
+      .send({ punishmentType: PunishmentType.LOSS_OF_SOCIAL_VISITS })
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Select whether the prisoner has any children under 18')
+      })
   })
 })

--- a/server/routes/punishmentsForReport/punishment/punishment.test.ts
+++ b/server/routes/punishmentsForReport/punishment/punishment.test.ts
@@ -105,13 +105,18 @@ describe('POST /punishment', () => {
       )
   })
 
-  it('shows an error when the child question is not answered', () => {
+  it.each([
+    [PunishmentType.LOSS_OF_SOCIAL_VISITS, 'lossHasChildUnder18'],
+    [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, 'restrictionHasChildUnder18'],
+  ])('links the missing child-answer error to the %s question', (punishmentType, childField) => {
     return request(app)
       .post(adjudicationUrls.punishment.urls.start('100'))
-      .send({ punishmentType: PunishmentType.LOSS_OF_SOCIAL_VISITS })
+      .send({ punishmentType })
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Select whether the prisoner has any children under 18')
+        expect(res.text).toContain(`href="#${childField}"`)
+        expect(res.text).toContain(`id="${childField}"`)
       })
   })
 })

--- a/server/routes/punishmentsForReport/punishment/punishmentEdit.test.ts
+++ b/server/routes/punishmentsForReport/punishment/punishmentEdit.test.ts
@@ -6,36 +6,26 @@ import adjudicationUrls from '../../../utils/urlGenerator'
 import UserService from '../../../services/userService'
 import PunishmentsService from '../../../services/punishmentsService'
 import { PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
-import ReportedAdjudicationsService from '../../../services/reportedAdjudicationsService'
-import TestData from '../../testutils/testData'
 
-const testData = new TestData()
 jest.mock('../../../services/userService')
 jest.mock('../../../services/punishmentsService')
-jest.mock('../../../services/reportedAdjudicationsService')
 
 const userService = new UserService(null, null) as jest.Mocked<UserService>
 const punishmentsService = new PunishmentsService(null, null) as jest.Mocked<PunishmentsService>
-const reportedAdjudicationsService = new ReportedAdjudicationsService(
-  null,
-  null,
-  null,
-  null,
-  null,
-) as jest.Mocked<ReportedAdjudicationsService>
 
 let app: Express
 
 beforeEach(() => {
-  app = appWithAllRoutes({ production: false }, { userService, punishmentsService, reportedAdjudicationsService }, {})
+  app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
   userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
   punishmentsService.getSessionPunishment.mockResolvedValue({
     type: PunishmentType.EARNINGS,
     stoppagePercentage: 25,
   })
-  reportedAdjudicationsService.getLatestHearing.mockResolvedValue(
-    testData.singleHearing({ id: 100, dateTimeOfHearing: '2022-11-03T11:00:00' }),
-  )
+  punishmentsService.getPunishmentAvailability.mockResolvedValue({
+    isIndependentAdjudicatorHearing: false,
+    socialVisitsAvailable: true,
+  })
 })
 
 afterEach(() => {
@@ -44,7 +34,7 @@ afterEach(() => {
 
 describe('GET /punishment', () => {
   beforeEach(() => {
-    app = appWithAllRoutes({ production: false }, { userService, punishmentsService, reportedAdjudicationsService }, {})
+    app = appWithAllRoutes({ production: false }, { userService, punishmentsService }, {})
     userService.getUserRoles.mockResolvedValue(['NOT_REVIEWER'])
   })
   it('should load the `Page not found` page', () => {
@@ -96,6 +86,22 @@ describe('POST /punishment', () => {
       .expect(
         'Location',
         `${adjudicationUrls.punishmentNumberOfDays.urls.edit('100', 'XYZ')}?punishmentType=EXTRA_WORK`,
+      )
+  })
+  it('preserves the child answer when editing a social visits punishment', () => {
+    return request(app)
+      .post(adjudicationUrls.punishment.urls.edit('100', 'XYZ'))
+      .send({
+        punishmentType: PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
+        restrictionHasChildUnder18: 'false',
+      })
+      .expect(302)
+      .expect(
+        'Location',
+        `${adjudicationUrls.punishmentNumberOfDays.urls.edit(
+          '100',
+          'XYZ',
+        )}?punishmentType=RESTRICTION_OF_SOCIAL_VISITS&hasChildUnder18=false`,
       )
   })
 })

--- a/server/routes/punishmentsForReport/punishment/punishmentPage.ts
+++ b/server/routes/punishmentsForReport/punishment/punishmentPage.ts
@@ -11,6 +11,8 @@ import {
   PunishmentDataWithSchedule,
   PunishmentType,
   RehabilitativeActivity,
+  isSocialVisitsPunishment,
+  parseHasChildUnder18,
 } from '../../../data/PunishmentResult'
 import PunishmentsService from '../../../services/punishmentsService'
 
@@ -21,6 +23,7 @@ type PageData = {
   otherPrivilege?: string
   stoppagePercentage?: number
   damagesOwedAmount?: number
+  hasChildUnder18?: boolean
 }
 
 export enum PageRequestType {
@@ -50,14 +53,21 @@ export default class PunishmentPage {
   private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
     const { chargeNumber } = req.params
     const { user } = res.locals
-    const { error, punishmentType, privilegeType, otherPrivilege, stoppagePercentage, damagesOwedAmount } = pageData
+    const {
+      error,
+      punishmentType,
+      privilegeType,
+      otherPrivilege,
+      stoppagePercentage,
+      damagesOwedAmount,
+      hasChildUnder18,
+    } = pageData
 
-    const isIndependentAdjudicatorHearing = await this.punishmentsService.checkAdditionalDaysAvailability(
-      chargeNumber,
-      user,
-    )
-
-    const sessionPunishments = await this.punishmentsService.getAllSessionPunishments(req, chargeNumber)
+    const [punishmentAvailability, sessionPunishments] = await Promise.all([
+      this.punishmentsService.getPunishmentAvailability(chargeNumber, user),
+      this.punishmentsService.getAllSessionPunishments(req, chargeNumber),
+    ])
+    const { isIndependentAdjudicatorHearing, socialVisitsAvailable } = punishmentAvailability
     const [damagesUnavailable, punishmentsAlreadyAdded, cautionAlreadyAdded] = await Promise.all([
       this.damagesAlreadyAdded(sessionPunishments),
       this.punishmentsAlreadyAdded(sessionPunishments),
@@ -74,6 +84,8 @@ export default class PunishmentPage {
       damagesUnavailable,
       cautionUnavailable: punishmentsAlreadyAdded || cautionAlreadyAdded,
       damagesOwedAmount,
+      hasChildUnder18,
+      socialVisitsAvailable,
     })
   }
 
@@ -93,6 +105,7 @@ export default class PunishmentPage {
         privilegeType: sessionData.privilegeType,
         otherPrivilege: sessionData.otherPrivilege,
         stoppagePercentage: sessionData.stoppagePercentage,
+        hasChildUnder18: sessionData.hasChildUnder18,
       })
     }
 
@@ -101,7 +114,18 @@ export default class PunishmentPage {
 
   submit = async (req: Request, res: Response): Promise<void> => {
     const { chargeNumber, redisId } = req.params
-    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, damagesOwedAmount } = req.body
+    const {
+      punishmentType,
+      privilegeType,
+      otherPrivilege,
+      stoppagePercentage,
+      damagesOwedAmount,
+      lossHasChildUnder18,
+      restrictionHasChildUnder18,
+    } = req.body
+    const hasChildUnder18 = parseHasChildUnder18(
+      punishmentType === PunishmentType.LOSS_OF_SOCIAL_VISITS ? lossHasChildUnder18 : restrictionHasChildUnder18,
+    )
 
     const sessionPunishments = await this.punishmentsService.getAllSessionPunishments(req, chargeNumber)
     const damagesAlreadyAdded = await this.damagesAlreadyAdded(sessionPunishments)
@@ -114,6 +138,7 @@ export default class PunishmentPage {
       stoppagePercentage: stoppageOfEarningsPercentage,
       damagesOwedAmount,
       damagesAlreadyAdded,
+      hasChildUnder18,
     })
     if (error)
       return this.renderView(req, res, {
@@ -123,6 +148,7 @@ export default class PunishmentPage {
         otherPrivilege,
         stoppagePercentage: stoppageOfEarningsPercentage,
         damagesOwedAmount,
+        hasChildUnder18,
       })
 
     if ([PunishmentType.CAUTION, PunishmentType.DAMAGES_OWED].includes(punishmentType)) {
@@ -141,7 +167,13 @@ export default class PunishmentPage {
     }
 
     const redirectUrlPrefix = this.getRedirectUrl(chargeNumber, req, punishmentType as PunishmentType)
-    const query = this.getQueryParamsToPass(punishmentType, privilegeType, otherPrivilege, stoppageOfEarningsPercentage)
+    const query = this.getQueryParamsToPass(
+      punishmentType,
+      privilegeType,
+      otherPrivilege,
+      stoppageOfEarningsPercentage,
+      hasChildUnder18,
+    )
     return res.redirect(
       url.format({
         pathname: redirectUrlPrefix,
@@ -155,7 +187,9 @@ export default class PunishmentPage {
     privilegeType: PrivilegeType,
     otherPrivilege: string,
     stoppageOfEarningsPercentage: number,
+    hasChildUnder18?: boolean,
   ) => {
+    if (isSocialVisitsPunishment(punishmentType)) return { punishmentType, hasChildUnder18 }
     if (this.pageOptions.isEdit()) {
       if (punishmentType === PunishmentType.PRIVILEGE && privilegeType === PrivilegeType.OTHER)
         return { punishmentType, privilegeType, otherPrivilege }

--- a/server/routes/punishmentsForReport/punishment/punishmentValidation.test.ts
+++ b/server/routes/punishmentsForReport/punishment/punishmentValidation.test.ts
@@ -34,6 +34,21 @@ describe('validateForm', () => {
       }),
     ).toBeNull()
   })
+  it.each([PunishmentType.LOSS_OF_SOCIAL_VISITS, PunishmentType.RESTRICTION_OF_SOCIAL_VISITS])(
+    'Valid submit has no errors for %s when the child question is answered',
+    punishmentType => {
+      expect(validateForm({ punishmentType, hasChildUnder18: false })).toBeNull()
+    },
+  )
+  it.each([
+    [PunishmentType.LOSS_OF_SOCIAL_VISITS, '#lossHasChildUnder18'],
+    [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, '#restrictionHasChildUnder18'],
+  ])('shows an error when the child question is not answered for %s', (punishmentType, href) => {
+    expect(validateForm({ punishmentType })).toEqual({
+      href,
+      text: 'Select whether the prisoner has any children under 18',
+    })
+  })
   it('shows error when no punishment option selected - damages previously added', () => {
     expect(
       validateForm({

--- a/server/routes/punishmentsForReport/punishment/punishmentValidation.ts
+++ b/server/routes/punishmentsForReport/punishment/punishmentValidation.ts
@@ -48,8 +48,12 @@ const errors: { [key: string]: FormError } = {
     href: '#amount',
     text: 'Enter the amount in numbers',
   },
-  MISSING_CHILD_UNDER_18: {
-    href: '#hasChildUnder18',
+  MISSING_CHILD_UNDER_18_LOSS_OF_SOCIAL_VISITS: {
+    href: '#lossHasChildUnder18',
+    text: 'Select whether the prisoner has any children under 18',
+  },
+  MISSING_CHILD_UNDER_18_RESTRICTION_OF_SOCIAL_VISITS: {
+    href: '#restrictionHasChildUnder18',
     text: 'Select whether the prisoner has any children under 18',
   },
 }
@@ -71,13 +75,9 @@ export default function validateForm({
   }
 
   if (isSocialVisitsPunishment(punishmentType) && hasChildUnder18 === undefined) {
-    return {
-      ...errors.MISSING_CHILD_UNDER_18,
-      href:
-        punishmentType === PunishmentType.LOSS_OF_SOCIAL_VISITS
-          ? '#lossHasChildUnder18'
-          : '#restrictionHasChildUnder18',
-    }
+    return punishmentType === PunishmentType.LOSS_OF_SOCIAL_VISITS
+      ? errors.MISSING_CHILD_UNDER_18_LOSS_OF_SOCIAL_VISITS
+      : errors.MISSING_CHILD_UNDER_18_RESTRICTION_OF_SOCIAL_VISITS
   }
 
   if (punishmentType === PunishmentType.PRIVILEGE && !privilegeType) return errors.MISSING_PRIVILEGE_TYPE

--- a/server/routes/punishmentsForReport/punishment/punishmentValidation.ts
+++ b/server/routes/punishmentsForReport/punishment/punishmentValidation.ts
@@ -1,5 +1,5 @@
 import { FormError } from '../../../@types/template'
-import { PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
+import { PrivilegeType, PunishmentType, isSocialVisitsPunishment } from '../../../data/PunishmentResult'
 
 type PunishmentForm = {
   punishmentType: PunishmentType
@@ -8,6 +8,7 @@ type PunishmentForm = {
   stoppagePercentage?: number
   damagesOwedAmount?: number
   damagesAlreadyAdded?: boolean
+  hasChildUnder18?: boolean
 }
 
 const errors: { [key: string]: FormError } = {
@@ -47,6 +48,10 @@ const errors: { [key: string]: FormError } = {
     href: '#amount',
     text: 'Enter the amount in numbers',
   },
+  MISSING_CHILD_UNDER_18: {
+    href: '#hasChildUnder18',
+    text: 'Select whether the prisoner has any children under 18',
+  },
 }
 
 export default function validateForm({
@@ -56,12 +61,23 @@ export default function validateForm({
   stoppagePercentage,
   damagesOwedAmount,
   damagesAlreadyAdded,
+  hasChildUnder18,
 }: PunishmentForm): FormError | null {
   if (!punishmentType) {
     if (damagesAlreadyAdded) {
       return errors.MISSING_PUNISHMENT_TYPE_DAMAGES_PRESENT
     }
     return errors.MISSING_PUNISHMENT_TYPE
+  }
+
+  if (isSocialVisitsPunishment(punishmentType) && hasChildUnder18 === undefined) {
+    return {
+      ...errors.MISSING_CHILD_UNDER_18,
+      href:
+        punishmentType === PunishmentType.LOSS_OF_SOCIAL_VISITS
+          ? '#lossHasChildUnder18'
+          : '#restrictionHasChildUnder18',
+    }
   }
 
   if (punishmentType === PunishmentType.PRIVILEGE && !privilegeType) return errors.MISSING_PRIVILEGE_TYPE

--- a/server/routes/punishmentsForReport/punishmentDates/autoPunishmentSchedule/autoPunishmentSchedule.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/autoPunishmentSchedule/autoPunishmentSchedule.test.ts
@@ -72,6 +72,7 @@ describe('GET', () => {
         expect(res.text).toContain('10 Apr 2023')
         expect(res.text).toContain('10')
         expect(res.text).toContain('19 Apr 2023')
+        expect(res.text).not.toContain('Prisoner has children under 18:')
       })
   })
 

--- a/server/routes/punishmentsForReport/punishmentDates/autoPunishmentSchedule/autoPunishmentSchedule.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/autoPunishmentSchedule/autoPunishmentSchedule.test.ts
@@ -74,4 +74,27 @@ describe('GET', () => {
         expect(res.text).toContain('19 Apr 2023')
       })
   })
+
+  it('displays the calculated last day and child answer for a social visits punishment', () => {
+    punishmentsService.getAllSessionPunishments.mockResolvedValue([
+      {
+        type: PunishmentType.LOSS_OF_SOCIAL_VISITS,
+        duration: 27,
+        startDate: '2023-12-13',
+        endDate: '2024-01-08',
+        hasChildUnder18: false,
+      },
+    ])
+
+    return request(app)
+      .get(adjudicationUrls.punishmentAutomaticDateSchedule.urls.start('100'))
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Loss of social visits')
+        expect(res.text).toContain('Prisoner has children under 18:')
+        expect(res.text).toContain('No')
+        expect(res.text).toContain('Last day')
+        expect(res.text).toContain('8 Jan 2024')
+      })
+  })
 })

--- a/server/routes/punishmentsForReport/punishmentDates/autoPunishmentSchedule/autoPunishmentSchedule.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/autoPunishmentSchedule/autoPunishmentSchedule.ts
@@ -17,6 +17,7 @@ type PageData = {
   otherPrivilege?: string
   stoppagePercentage?: number
   redisId?: string
+  hasChildUnder18?: boolean
 }
 
 export default class AutoPunishmentSchedulePage {
@@ -28,7 +29,17 @@ export default class AutoPunishmentSchedulePage {
 
   private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
     const { chargeNumber } = req.params
-    const { startDate, endDate, duration, type, privilegeType, otherPrivilege, stoppagePercentage, redisId } = pageData
+    const {
+      startDate,
+      endDate,
+      duration,
+      type,
+      privilegeType,
+      otherPrivilege,
+      stoppagePercentage,
+      redisId,
+      hasChildUnder18,
+    } = pageData
 
     const startDateChangeHref = url.format({
       pathname: adjudicationUrls.punishmentStartDate.urls.edit(chargeNumber, redisId),
@@ -37,6 +48,7 @@ export default class AutoPunishmentSchedulePage {
         privilegeType,
         otherPrivilege,
         stoppagePercentage,
+        ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
         duration,
       } as ParsedUrlQueryInput,
     })
@@ -48,6 +60,7 @@ export default class AutoPunishmentSchedulePage {
         privilegeType,
         otherPrivilege,
         stoppagePercentage,
+        ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
         duration,
       } as ParsedUrlQueryInput,
     })
@@ -64,6 +77,7 @@ export default class AutoPunishmentSchedulePage {
       otherPrivilege,
       stoppagePercentage,
       redisId,
+      hasChildUnder18,
     })
   }
 
@@ -89,6 +103,7 @@ export default class AutoPunishmentSchedulePage {
       otherPrivilege: lastAddedPunishment.otherPrivilege,
       stoppagePercentage: lastAddedPunishment.stoppagePercentage,
       redisId: lastAddedPunishment.redisId,
+      hasChildUnder18: lastAddedPunishment.hasChildUnder18,
     })
   }
 }

--- a/server/routes/punishmentsForReport/punishmentDates/enterStartDate/enterStartDate.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/enterStartDate/enterStartDate.test.ts
@@ -118,6 +118,8 @@ describe('POST ', () => {
             type: PunishmentType.LOSS_OF_SOCIAL_VISITS,
             hasChildUnder18: false,
             duration: 27,
+            startDate: '2023-12-13',
+            endDate: '2024-01-08',
           }),
           '100',
         ),

--- a/server/routes/punishmentsForReport/punishmentDates/enterStartDate/enterStartDate.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/enterStartDate/enterStartDate.test.ts
@@ -101,4 +101,26 @@ describe('POST ', () => {
         ),
       )
   })
+
+  it('saves the child answer for a social visits punishment', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.punishmentStartDate.urls.start(
+          '100',
+        )}?punishmentType=LOSS_OF_SOCIAL_VISITS&hasChildUnder18=false&duration=27`,
+      )
+      .send({ startDate: '13/12/2023' })
+      .expect(302)
+      .then(() =>
+        expect(punishmentsService.addSessionPunishment).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            type: PunishmentType.LOSS_OF_SOCIAL_VISITS,
+            hasChildUnder18: false,
+            duration: 27,
+          }),
+          '100',
+        ),
+      )
+  })
 })

--- a/server/routes/punishmentsForReport/punishmentDates/enterStartDate/enterStartDatePage.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/enterStartDate/enterStartDatePage.ts
@@ -9,7 +9,12 @@ import adjudicationUrls from '../../../../utils/urlGenerator'
 import PunishmentsService from '../../../../services/punishmentsService'
 import ReportedAdjudicationsService from '../../../../services/reportedAdjudicationsService'
 import validateForm from './enterStartDateValidation'
-import { PrivilegeType, PunishmentType, RehabilitativeActivity } from '../../../../data/PunishmentResult'
+import {
+  PrivilegeType,
+  PunishmentType,
+  RehabilitativeActivity,
+  parseHasChildUnder18,
+} from '../../../../data/PunishmentResult'
 
 type PageData = {
   error?: FormError
@@ -73,9 +78,10 @@ export default class PunishmentStartDatePage {
   submit = async (req: Request, res: Response): Promise<void> => {
     const { chargeNumber } = req.params
     const { startDate } = req.body
-    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, duration } = req.query
+    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, hasChildUnder18, duration } = req.query
     const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
     const numberOfDays = Number(duration)
+    const childUnder18 = parseHasChildUnder18(hasChildUnder18)
 
     const error = validateForm({
       startDate,
@@ -93,6 +99,7 @@ export default class PunishmentStartDatePage {
         privilegeType: privilegeType ? PrivilegeType[privilegeType as keyof typeof PrivilegeType] : null,
         otherPrivilege: otherPrivilege ? (otherPrivilege as string) : null,
         stoppagePercentage: stoppagePercentage ? Number(stoppagePercentage) : null,
+        ...(childUnder18 !== undefined && { hasChildUnder18: childUnder18 }),
         duration: numberOfDays,
         startDate: datePickerToApi(startDate),
         endDate: calculatePunishmentEndDate(startDate, numberOfDays, 'YYYY-MM-DD'),
@@ -115,6 +122,7 @@ export default class PunishmentStartDatePage {
         privilegeType,
         otherPrivilege,
         stoppagePercentage,
+        ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
         duration,
         startDate,
       } as ParsedUrlQueryInput,

--- a/server/routes/punishmentsForReport/punishmentDates/isPunishmentSuspended/isPunishmentSuspendedPage.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/isPunishmentSuspended/isPunishmentSuspendedPage.ts
@@ -72,7 +72,7 @@ export default class PunishmentSuspendedPage {
   submit = async (req: Request, res: Response): Promise<void> => {
     const { chargeNumber } = req.params
     const { suspended } = req.body
-    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, duration } = req.query
+    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, hasChildUnder18, duration } = req.query
 
     const error = validateForm({
       suspended,
@@ -93,6 +93,7 @@ export default class PunishmentSuspendedPage {
           privilegeType,
           otherPrivilege,
           stoppagePercentage,
+          ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
           duration,
         } as ParsedUrlQueryInput,
       }),

--- a/server/routes/punishmentsForReport/punishmentDates/numberOfDays/numberOfDays.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/numberOfDays/numberOfDays.test.ts
@@ -6,6 +6,7 @@ import UserService from '../../../../services/userService'
 import PunishmentsService from '../../../../services/punishmentsService'
 import ReportedAdjudicationsService from '../../../../services/reportedAdjudicationsService'
 import TestData from '../../../testutils/testData'
+import { PunishmentType } from '../../../../data/PunishmentResult'
 
 jest.mock('../../../../services/userService')
 jest.mock('../../../../services/punishmentsService')
@@ -91,6 +92,38 @@ describe('POST ', () => {
         `${adjudicationUrls.punishmentIsSuspended.urls.start(
           '100',
         )}?punishmentType=PRIVILEGE&privilegeType=OTHER&otherPrivilege=nintendo%20switch&stoppagePercentage=&duration=2`,
+      )
+  })
+
+  it('shows the ticket validation message and keeps the invalid loss duration editable', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.punishmentNumberOfDays.urls.start(
+          '100',
+        )}?punishmentType=${PunishmentType.LOSS_OF_SOCIAL_VISITS}&hasChildUnder18=false`,
+      )
+      .send({ duration: 28 })
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Days for Loss of Social Visits cannot be more than 27 days')
+        expect(res.text).toContain('value="28"')
+      })
+  })
+
+  it('accepts the corrected maximum loss duration and carries the child answer forward', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.punishmentNumberOfDays.urls.start(
+          '100',
+        )}?punishmentType=${PunishmentType.LOSS_OF_SOCIAL_VISITS}&hasChildUnder18=false`,
+      )
+      .send({ duration: 27 })
+      .expect(302)
+      .expect(
+        'Location',
+        `${adjudicationUrls.punishmentIsSuspended.urls.start(
+          '100',
+        )}?punishmentType=LOSS_OF_SOCIAL_VISITS&privilegeType=&otherPrivilege=&stoppagePercentage=&hasChildUnder18=false&duration=27`,
       )
   })
 })

--- a/server/routes/punishmentsForReport/punishmentDates/numberOfDays/numberOfDaysPage.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/numberOfDays/numberOfDaysPage.ts
@@ -75,7 +75,7 @@ export default class PunishmentNumberOfDaysPage {
     const { chargeNumber } = req.params
     const { user } = res.locals
     const { duration } = req.body
-    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage } = req.query
+    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, hasChildUnder18 } = req.query
     const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
 
     const trimmedDays = duration ? Number(String(duration).trim()) : null
@@ -103,6 +103,7 @@ export default class PunishmentNumberOfDaysPage {
           privilegeType,
           otherPrivilege,
           stoppagePercentage,
+          ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
           duration: trimmedDays,
         } as ParsedUrlQueryInput,
       }),

--- a/server/routes/punishmentsForReport/punishmentDates/startDateChoice/startDateChoicePage.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/startDateChoice/startDateChoicePage.ts
@@ -10,7 +10,12 @@ import PunishmentsService from '../../../../services/punishmentsService'
 import ReportedAdjudicationsService from '../../../../services/reportedAdjudicationsService'
 import validateForm from './startDateChoiceValidation'
 import { User } from '../../../../data/hmppsManageUsersClient'
-import { PrivilegeType, PunishmentType, RehabilitativeActivity } from '../../../../data/PunishmentResult'
+import {
+  PrivilegeType,
+  PunishmentType,
+  RehabilitativeActivity,
+  parseHasChildUnder18,
+} from '../../../../data/PunishmentResult'
 
 type PageData = {
   error?: FormError
@@ -81,8 +86,9 @@ export default class PunishmentStartDateChoicePage {
     const { chargeNumber } = req.params
     const { immediate } = req.body
     const { user } = res.locals
-    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, duration } = req.query
+    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, hasChildUnder18, duration } = req.query
     const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
+    const childUnder18 = parseHasChildUnder18(hasChildUnder18)
 
     const error = validateForm({
       immediate,
@@ -106,6 +112,7 @@ export default class PunishmentStartDateChoicePage {
           privilegeType: privilegeType ? PrivilegeType[privilegeType as keyof typeof PrivilegeType] : null,
           otherPrivilege: otherPrivilege ? (otherPrivilege as string) : null,
           stoppagePercentage: stoppagePercentage ? Number(stoppagePercentage) : null,
+          ...(childUnder18 !== undefined && { hasChildUnder18: childUnder18 }),
           duration: numberOfDays,
           startDate,
           endDate: calculatePunishmentEndDate(lastHearingDate, numberOfDays, 'YYYY-MM-DD'),
@@ -131,6 +138,7 @@ export default class PunishmentStartDateChoicePage {
           privilegeType,
           otherPrivilege,
           stoppagePercentage,
+          ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
           duration,
           startDate: lastHearingDate,
         } as ParsedUrlQueryInput,

--- a/server/routes/punishmentsForReport/punishmentDates/suspendedUntilDate/suspendedUntilDate.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/suspendedUntilDate/suspendedUntilDate.test.ts
@@ -27,6 +27,10 @@ beforeEach(() => {
   app = appWithAllRoutes({ production: false }, { userService, punishmentsService, reportedAdjudicationsService }, {})
   userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
   punishmentsService.addSessionPunishment.mockResolvedValue('abc')
+  punishmentsService.getPunishmentAvailability.mockResolvedValue({
+    isIndependentAdjudicatorHearing: false,
+    socialVisitsAvailable: true,
+  })
 })
 
 afterEach(() => {
@@ -92,6 +96,29 @@ describe('POST ', () => {
             stoppagePercentage: null,
             rehabilitativeActivities: [],
           },
+          '100',
+        ),
+      )
+  })
+
+  it('saves a suspended social visits punishment and offers rehabilitative activities', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.punishmentSuspendedUntil.urls.start(
+          '100',
+        )}?punishmentType=RESTRICTION_OF_SOCIAL_VISITS&hasChildUnder18=true&duration=84`,
+      )
+      .send({ suspendedUntil: '13/12/2023' })
+      .expect(302)
+      .expect('Location', adjudicationUrls.punishmentHasRehabilitativeActivities.urls.start('100', 'abc'))
+      .then(() =>
+        expect(punishmentsService.addSessionPunishment).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            type: PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
+            hasChildUnder18: true,
+            duration: 84,
+          }),
           '100',
         ),
       )

--- a/server/routes/punishmentsForReport/punishmentDates/suspendedUntilDate/suspendedUntilDateEdit.test.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/suspendedUntilDate/suspendedUntilDateEdit.test.ts
@@ -26,6 +26,10 @@ let app: Express
 beforeEach(() => {
   app = appWithAllRoutes({ production: false }, { userService, punishmentsService, reportedAdjudicationsService }, {})
   userService.getUserRoles.mockResolvedValue(['ADJUDICATIONS_REVIEWER'])
+  punishmentsService.getPunishmentAvailability.mockResolvedValue({
+    isIndependentAdjudicatorHearing: false,
+    socialVisitsAvailable: true,
+  })
   punishmentsService.getSessionPunishment.mockResolvedValue({
     type: PunishmentType.PRIVILEGE,
     PrivilegeType: PrivilegeType.OTHER,

--- a/server/routes/punishmentsForReport/punishmentDates/suspendedUntilDate/suspendedUntilDatePage.ts
+++ b/server/routes/punishmentsForReport/punishmentDates/suspendedUntilDate/suspendedUntilDatePage.ts
@@ -7,7 +7,12 @@ import { hasAnyRole, apiDateToDatePicker, datePickerToApi } from '../../../../ut
 import adjudicationUrls from '../../../../utils/urlGenerator'
 import PunishmentsService from '../../../../services/punishmentsService'
 import ReportedAdjudicationsService from '../../../../services/reportedAdjudicationsService'
-import { PrivilegeType, PunishmentType, RehabilitativeActivity } from '../../../../data/PunishmentResult'
+import {
+  PrivilegeType,
+  PunishmentType,
+  RehabilitativeActivity,
+  parseHasChildUnder18,
+} from '../../../../data/PunishmentResult'
 
 type PageData = {
   error?: FormError
@@ -72,8 +77,9 @@ export default class SuspendedUntilDatePage {
     const { chargeNumber } = req.params
     const { suspendedUntil } = req.body
     const { user } = res.locals
-    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, duration } = req.query
+    const { punishmentType, privilegeType, otherPrivilege, stoppagePercentage, hasChildUnder18, duration } = req.query
     const type = PunishmentType[punishmentType as keyof typeof PunishmentType]
+    const childUnder18 = parseHasChildUnder18(hasChildUnder18)
 
     const error = validateForm({
       suspendedUntil,
@@ -92,6 +98,7 @@ export default class SuspendedUntilDatePage {
         privilegeType: privilegeType ? PrivilegeType[privilegeType as keyof typeof PrivilegeType] : null,
         otherPrivilege: otherPrivilege ? (otherPrivilege as string) : null,
         stoppagePercentage: stoppagePercentage ? Number(stoppagePercentage) : null,
+        ...(childUnder18 !== undefined && { hasChildUnder18: childUnder18 }),
         duration: Number(duration),
         suspendedUntil: suspendedUntil ? datePickerToApi(suspendedUntil) : null,
         rehabilitativeActivities: [] as RehabilitativeActivity[],
@@ -106,7 +113,11 @@ export default class SuspendedUntilDatePage {
       throw postError
     }
 
-    const isGovernerHearing = !(await this.punishmentsService.checkAdditionalDaysAvailability(chargeNumber, user))
+    const { isIndependentAdjudicatorHearing } = await this.punishmentsService.getPunishmentAvailability(
+      chargeNumber,
+      user,
+    )
+    const isGovernerHearing = !isIndependentAdjudicatorHearing
 
     if (
       isGovernerHearing &&
@@ -118,6 +129,8 @@ export default class SuspendedUntilDatePage {
         PunishmentType.PRIVILEGE,
         PunishmentType.REMOVAL_ACTIVITY,
         PunishmentType.REMOVAL_WING,
+        PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
+        PunishmentType.LOSS_OF_SOCIAL_VISITS,
       ].includes(type)
     ) {
       return res.redirect(adjudicationUrls.punishmentHasRehabilitativeActivities.urls.start(chargeNumber, redisId))

--- a/server/routes/punishmentsForReport/punishmentSuspendedDates/autoPunishmentSchedule/autoPunishmentSchedulePage.ts
+++ b/server/routes/punishmentsForReport/punishmentSuspendedDates/autoPunishmentSchedule/autoPunishmentSchedulePage.ts
@@ -5,7 +5,7 @@ import UserService from '../../../../services/userService'
 import { hasAnyRole } from '../../../../utils/utils'
 import adjudicationUrls from '../../../../utils/urlGenerator'
 import PunishmentsService from '../../../../services/punishmentsService'
-import { PrivilegeType, PunishmentType } from '../../../../data/PunishmentResult'
+import { PrivilegeType, PunishmentType, isSocialVisitsPunishment } from '../../../../data/PunishmentResult'
 
 type PageData = {
   startDate?: string
@@ -17,6 +17,7 @@ type PageData = {
   stoppagePercentage?: number
   redisId?: string
   chargeNumberForSuspendedPunishment?: string
+  hasChildUnder18?: boolean
 }
 
 export default class AutoPunishmentSuspendedSchedulePage {
@@ -37,6 +38,7 @@ export default class AutoPunishmentSuspendedSchedulePage {
       stoppagePercentage,
       redisId,
       chargeNumberForSuspendedPunishment,
+      hasChildUnder18,
     } = pageData
     const { punishmentNumberToActivate } = req.query
 
@@ -56,18 +58,20 @@ export default class AutoPunishmentSuspendedSchedulePage {
       } as ParsedUrlQueryInput,
     })
 
-    const daysChangeHref = url.format({
-      pathname: daysPath,
-      query: {
-        punishmentType: type,
-        privilegeType,
-        otherPrivilege,
-        stoppagePercentage,
-        duration,
-        punishmentNumberToActivate,
-        chargeNumberForSuspendedPunishment,
-      } as ParsedUrlQueryInput,
-    })
+    const daysChangeHref = isSocialVisitsPunishment(type)
+      ? null
+      : url.format({
+          pathname: daysPath,
+          query: {
+            punishmentType: type,
+            privilegeType,
+            otherPrivilege,
+            stoppagePercentage,
+            duration,
+            punishmentNumberToActivate,
+            chargeNumberForSuspendedPunishment,
+          } as ParsedUrlQueryInput,
+        })
 
     return res.render(`pages/autoPunishmentSchedule.njk`, {
       chargeNumber,
@@ -82,6 +86,7 @@ export default class AutoPunishmentSuspendedSchedulePage {
       otherPrivilege,
       stoppagePercentage,
       redisId,
+      hasChildUnder18,
     })
   }
 
@@ -108,6 +113,7 @@ export default class AutoPunishmentSuspendedSchedulePage {
       stoppagePercentage: lastAddedPunishment.stoppagePercentage,
       redisId: lastAddedPunishment.redisId,
       chargeNumberForSuspendedPunishment: lastAddedPunishment.activatedFrom,
+      hasChildUnder18: lastAddedPunishment.hasChildUnder18,
     })
   }
 

--- a/server/routes/punishmentsForReport/punishmentSuspendedDates/startDateChoice/startDateChoice.test.ts
+++ b/server/routes/punishmentsForReport/punishmentSuspendedDates/startDateChoice/startDateChoice.test.ts
@@ -87,6 +87,20 @@ beforeEach(() => {
           },
         },
       },
+      {
+        chargeNumber: '105',
+        corrupted: false,
+        punishment: {
+          id: 75,
+          type: PunishmentType.LOSS_OF_SOCIAL_VISITS,
+          hasChildUnder18: false,
+          rehabilitativeActivities: [],
+          schedule: {
+            duration: 27,
+            suspendedUntil: '18/5/2023',
+          },
+        },
+      },
     ],
   })
 })
@@ -156,6 +170,29 @@ describe('POST ', () => {
         `${adjudicationUrls.suspendedPunishmentStartDate.urls.existing(
           '100',
         )}?punishmentType=CONFINEMENT&privilegeType=&otherPrivilege=&stoppagePercentage=&duration=&startDate=&punishmentNumberToActivate=72&chargeNumberForSuspendedPunishment=`,
+      )
+  })
+
+  it('preserves the child answer when activating a social visits punishment', () => {
+    return request(app)
+      .post(
+        `${adjudicationUrls.suspendedPunishmentStartDateChoice.urls.existing(
+          '100',
+        )}?punishmentType=LOSS_OF_SOCIAL_VISITS&duration=27&punishmentNumberToActivate=75`,
+      )
+      .send({ immediate: 'true' })
+      .expect(302)
+      .then(() =>
+        expect(punishmentsService.addSessionPunishment).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            type: PunishmentType.LOSS_OF_SOCIAL_VISITS,
+            hasChildUnder18: false,
+            duration: 27,
+            activatedFrom: '105',
+          }),
+          '100',
+        ),
       )
   })
 })

--- a/server/routes/punishmentsForReport/punishments/activateSuspendedPunishments/activateSuspendedPunishments.test.ts
+++ b/server/routes/punishmentsForReport/punishments/activateSuspendedPunishments/activateSuspendedPunishments.test.ts
@@ -131,4 +131,30 @@ describe('POST', () => {
         )}?punishmentNumberToActivate=60&punishmentType=PRIVILEGE&duration=5`,
       )
   })
+
+  it('skips the duration page when activating a social visits punishment', () => {
+    punishmentsService.getSuspendedPunishment.mockResolvedValue([
+      {
+        chargeNumber: '101',
+        corrupted: false,
+        punishment: {
+          id: 80,
+          type: PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
+          hasChildUnder18: true,
+          rehabilitativeActivities: [],
+          schedule: { duration: 84, suspendedUntil: '2023-05-20' },
+        },
+      },
+    ])
+
+    return request(app)
+      .post(adjudicationUrls.activateSuspendedPunishments.urls.start('100'))
+      .send({ activate: 'suspended-punishment-80' })
+      .expect(
+        'Location',
+        `${adjudicationUrls.suspendedPunishmentStartDateChoice.urls.existing(
+          '100',
+        )}?punishmentNumberToActivate=80&punishmentType=RESTRICTION_OF_SOCIAL_VISITS&duration=84`,
+      )
+  })
 })

--- a/server/routes/punishmentsForReport/punishments/activateSuspendedPunishments/activateSuspendedPunishmentsPage.ts
+++ b/server/routes/punishmentsForReport/punishments/activateSuspendedPunishments/activateSuspendedPunishmentsPage.ts
@@ -6,7 +6,7 @@ import UserService from '../../../../services/userService'
 import adjudicationUrls from '../../../../utils/urlGenerator'
 import { hasAnyRole } from '../../../../utils/utils'
 import PunishmentsService from '../../../../services/punishmentsService'
-import { PunishmentDataWithSchedule } from '../../../../data/PunishmentResult'
+import { PunishmentDataWithSchedule, PunishmentType, isSocialVisitsPunishment } from '../../../../data/PunishmentResult'
 
 export default class ActivateSuspendedPunishmentsPage {
   constructor(
@@ -65,7 +65,7 @@ export default class ActivateSuspendedPunishmentsPage {
     const punishmentType = punishmentToActivate[0].punishment.type
     const { duration } = punishmentToActivate[0].punishment.schedule
 
-    const redirectUrl = this.getRedirectUrl(chargeNumber)
+    const redirectUrl = this.getRedirectUrl(chargeNumber, punishmentType)
     return res.redirect(
       url.format({
         pathname: redirectUrl,
@@ -74,7 +74,10 @@ export default class ActivateSuspendedPunishmentsPage {
     )
   }
 
-  getRedirectUrl = (chargeNumber: string) => {
+  getRedirectUrl = (chargeNumber: string, punishmentType: PunishmentType) => {
+    if (isSocialVisitsPunishment(punishmentType)) {
+      return adjudicationUrls.suspendedPunishmentStartDateChoice.urls.existing(chargeNumber)
+    }
     return adjudicationUrls.suspendedPunishmentNumberOfDays.urls.existing(chargeNumber)
   }
 }

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
@@ -2,6 +2,39 @@ import { PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
 import validateForm from './punishmentDaysValidator'
 
 describe('validateForm', () => {
+  describe('Social visits validation', () => {
+    it.each([
+      [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, 84],
+      [PunishmentType.LOSS_OF_SOCIAL_VISITS, 27],
+    ])('allows %s at its policy maximum', (punishmentType, duration) => {
+      expect(validateForm(punishmentType, duration, false)).toBeNull()
+    })
+
+    it.each([
+      [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, 85, 'Restriction of social visits cannot be more than 84 days'],
+      [PunishmentType.LOSS_OF_SOCIAL_VISITS, 28, 'Loss of social visits cannot be more than 27 days'],
+    ])('rejects %s above its policy maximum', (punishmentType, duration, text) => {
+      expect(validateForm(punishmentType, duration, false)).toEqual({ href: '#duration', text })
+    })
+
+    it.each([PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, PunishmentType.LOSS_OF_SOCIAL_VISITS])(
+      'rejects %s for a YOI adjudication',
+      punishmentType => {
+        expect(validateForm(punishmentType, 1, true)).toEqual({
+          href: '#duration',
+          text: 'Social visits punishments are only available for offences under Adult rules',
+        })
+      },
+    )
+
+    it.each([1.5, Number.NaN])('rejects a non-whole social visits duration: %s', duration => {
+      expect(validateForm(PunishmentType.LOSS_OF_SOCIAL_VISITS, duration, false)).toEqual({
+        href: '#duration',
+        text: 'Enter the number of whole days the social visits punishment will last',
+      })
+    })
+  })
+
   describe('Additional days validation', () => {
     describe('for adults', () => {
       const IS_YOI = false

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.test.ts
@@ -11,8 +11,12 @@ describe('validateForm', () => {
     })
 
     it.each([
-      [PunishmentType.RESTRICTION_OF_SOCIAL_VISITS, 85, 'Restriction of social visits cannot be more than 84 days'],
-      [PunishmentType.LOSS_OF_SOCIAL_VISITS, 28, 'Loss of social visits cannot be more than 27 days'],
+      [
+        PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
+        85,
+        'Days for Restriction of Social Visits cannot be more than 84 days',
+      ],
+      [PunishmentType.LOSS_OF_SOCIAL_VISITS, 28, 'Days for Loss of Social Visits cannot be more than 27 days'],
     ])('rejects %s above its policy maximum', (punishmentType, duration, text) => {
       expect(validateForm(punishmentType, duration, false)).toEqual({ href: '#duration', text })
     })

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
@@ -77,11 +77,11 @@ const errors: { [key: string]: FormError } = {
   },
   RESTRICTION_OF_SOCIAL_VISITS_MAX: {
     href: '#duration',
-    text: 'Restriction of social visits cannot be more than 84 days',
+    text: 'Days for Restriction of Social Visits cannot be more than 84 days',
   },
   LOSS_OF_SOCIAL_VISITS_MAX: {
     href: '#duration',
-    text: 'Loss of social visits cannot be more than 27 days',
+    text: 'Days for Loss of Social Visits cannot be more than 27 days',
   },
 }
 

--- a/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
+++ b/server/routes/punishmentsForReport/punishments/punishmentDaysValidator.ts
@@ -1,5 +1,10 @@
 import { FormError } from '../../../@types/template'
-import { convertPrivilegeType, PrivilegeType, PunishmentType } from '../../../data/PunishmentResult'
+import {
+  convertPrivilegeType,
+  PrivilegeType,
+  PunishmentType,
+  isSocialVisitsPunishment,
+} from '../../../data/PunishmentResult'
 
 const errors: { [key: string]: FormError } = {
   ADDITIONAL_DAYS_MAX_ADULT: {
@@ -62,6 +67,22 @@ const errors: { [key: string]: FormError } = {
     href: '#duration',
     text: 'Days for extra work cannot be more than 21 days for an offence under YOI rules',
   },
+  SOCIAL_VISITS_YOI: {
+    href: '#duration',
+    text: 'Social visits punishments are only available for offences under Adult rules',
+  },
+  SOCIAL_VISITS_WHOLE_DAYS: {
+    href: '#duration',
+    text: 'Enter the number of whole days the social visits punishment will last',
+  },
+  RESTRICTION_OF_SOCIAL_VISITS_MAX: {
+    href: '#duration',
+    text: 'Restriction of social visits cannot be more than 84 days',
+  },
+  LOSS_OF_SOCIAL_VISITS_MAX: {
+    href: '#duration',
+    text: 'Loss of social visits cannot be more than 27 days',
+  },
 }
 
 export default function validatePunishmentDays(
@@ -71,6 +92,22 @@ export default function validatePunishmentDays(
   privilegeType?: PrivilegeType,
 ): FormError | null {
   const isAdult = !isYOI
+
+  if (isSocialVisitsPunishment(punishmentType) && isYOI) {
+    return errors.SOCIAL_VISITS_YOI
+  }
+
+  if (isSocialVisitsPunishment(punishmentType) && !Number.isInteger(duration)) {
+    return errors.SOCIAL_VISITS_WHOLE_DAYS
+  }
+
+  if (punishmentType === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS && duration > 84) {
+    return errors.RESTRICTION_OF_SOCIAL_VISITS_MAX
+  }
+
+  if (punishmentType === PunishmentType.LOSS_OF_SOCIAL_VISITS && duration > 27) {
+    return errors.LOSS_OF_SOCIAL_VISITS_MAX
+  }
 
   if (punishmentType === PunishmentType.ADDITIONAL_DAYS) {
     if (isAdult && duration > 84) {

--- a/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivity.ts
+++ b/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivity.ts
@@ -62,17 +62,14 @@ export default class IncompleteRehabilitativeActivityPage {
     const { outcome, daysToActivate, suspendedUntil } = req.body
     const { user } = res.locals
 
-    const { prisonerName, actualDays, punishmentType } =
-      await this.punishmentsService.getRehabilitativeActivitiesCompletionDetails(req, chargeNumber, +id, user)
+    const { prisonerName, actualDays } = await this.punishmentsService.getRehabilitativeActivitiesCompletionDetails(
+      req,
+      chargeNumber,
+      +id,
+      user,
+    )
 
-    const error = validateForm({
-      outcome,
-      daysToActivate,
-      suspendedUntil,
-      prisonerName,
-      actualDays,
-      punishmentType,
-    })
+    const error = validateForm({ outcome, daysToActivate, suspendedUntil, prisonerName, actualDays })
 
     if (error) {
       return this.renderView(req, res, {

--- a/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivity.ts
+++ b/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivity.ts
@@ -62,14 +62,17 @@ export default class IncompleteRehabilitativeActivityPage {
     const { outcome, daysToActivate, suspendedUntil } = req.body
     const { user } = res.locals
 
-    const { prisonerName, actualDays } = await this.punishmentsService.getRehabilitativeActivitiesCompletionDetails(
-      req,
-      chargeNumber,
-      +id,
-      user,
-    )
+    const { prisonerName, actualDays, punishmentType } =
+      await this.punishmentsService.getRehabilitativeActivitiesCompletionDetails(req, chargeNumber, +id, user)
 
-    const error = validateForm({ outcome, daysToActivate, suspendedUntil, prisonerName, actualDays })
+    const error = validateForm({
+      outcome,
+      daysToActivate,
+      suspendedUntil,
+      prisonerName,
+      actualDays,
+      punishmentType,
+    })
 
     if (error) {
       return this.renderView(req, res, {

--- a/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.test.ts
+++ b/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.test.ts
@@ -1,4 +1,4 @@
-import { NotCompletedOutcome, PunishmentType } from '../../../../data/PunishmentResult'
+import { NotCompletedOutcome } from '../../../../data/PunishmentResult'
 import validateForm from './incompleteRehabilitativeActivityValidation'
 
 describe('incomplete rehab activity validation', () => {
@@ -80,21 +80,6 @@ describe('incomplete rehab activity validation', () => {
     ).toEqual({
       href: '#daysToActivate',
       text: `The number of days for the punishment must be 5 or fewer`,
-    })
-  })
-  it('limits partial activation of a social visits punishment to 28 days', () => {
-    expect(
-      validateForm({
-        outcome: NotCompletedOutcome.PARTIAL_ACTIVATE,
-        daysToActivate: 29,
-        suspendedUntil: null,
-        prisonerName: 'John Smith',
-        actualDays: 84,
-        punishmentType: PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
-      }),
-    ).toEqual({
-      href: '#daysToActivate',
-      text: 'The number of days for a social visits punishment must be 28 or fewer',
     })
   })
   it('Extended chosen but no date entered', () => {

--- a/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.test.ts
+++ b/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.test.ts
@@ -1,4 +1,4 @@
-import { NotCompletedOutcome } from '../../../../data/PunishmentResult'
+import { NotCompletedOutcome, PunishmentType } from '../../../../data/PunishmentResult'
 import validateForm from './incompleteRehabilitativeActivityValidation'
 
 describe('incomplete rehab activity validation', () => {
@@ -80,6 +80,21 @@ describe('incomplete rehab activity validation', () => {
     ).toEqual({
       href: '#daysToActivate',
       text: `The number of days for the punishment must be 5 or fewer`,
+    })
+  })
+  it('limits partial activation of a social visits punishment to 28 days', () => {
+    expect(
+      validateForm({
+        outcome: NotCompletedOutcome.PARTIAL_ACTIVATE,
+        daysToActivate: 29,
+        suspendedUntil: null,
+        prisonerName: 'John Smith',
+        actualDays: 84,
+        punishmentType: PunishmentType.RESTRICTION_OF_SOCIAL_VISITS,
+      }),
+    ).toEqual({
+      href: '#daysToActivate',
+      text: 'The number of days for a social visits punishment must be 28 or fewer',
     })
   })
   it('Extended chosen but no date entered', () => {

--- a/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.ts
+++ b/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.ts
@@ -1,5 +1,5 @@
 import { FormError } from '../../../../@types/template'
-import { NotCompletedOutcome } from '../../../../data/PunishmentResult'
+import { NotCompletedOutcome, PunishmentType, isSocialVisitsPunishment } from '../../../../data/PunishmentResult'
 import { isValidDateFormat, possessive } from '../../../../utils/utils'
 
 type NotCompletedForm = {
@@ -8,6 +8,7 @@ type NotCompletedForm = {
   suspendedUntil: string
   prisonerName: string
   actualDays: number
+  punishmentType?: PunishmentType
 }
 
 export default function validateForm({
@@ -16,6 +17,7 @@ export default function validateForm({
   suspendedUntil,
   prisonerName,
   actualDays,
+  punishmentType,
 }: NotCompletedForm): FormError | null {
   if (!outcome) {
     return {
@@ -40,6 +42,12 @@ export default function validateForm({
       return {
         href: '#daysToActivate',
         text: `The number of days for the punishment must be ${actualDays} or fewer`,
+      }
+    }
+    if (isSocialVisitsPunishment(punishmentType) && daysToActivate > 28) {
+      return {
+        href: '#daysToActivate',
+        text: 'The number of days for a social visits punishment must be 28 or fewer',
       }
     }
   }

--- a/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.ts
+++ b/server/routes/punishmentsForReport/rehabilitativeActivities/incomplete/incompleteRehabilitativeActivityValidation.ts
@@ -1,5 +1,5 @@
 import { FormError } from '../../../../@types/template'
-import { NotCompletedOutcome, PunishmentType, isSocialVisitsPunishment } from '../../../../data/PunishmentResult'
+import { NotCompletedOutcome } from '../../../../data/PunishmentResult'
 import { isValidDateFormat, possessive } from '../../../../utils/utils'
 
 type NotCompletedForm = {
@@ -8,7 +8,6 @@ type NotCompletedForm = {
   suspendedUntil: string
   prisonerName: string
   actualDays: number
-  punishmentType?: PunishmentType
 }
 
 export default function validateForm({
@@ -17,7 +16,6 @@ export default function validateForm({
   suspendedUntil,
   prisonerName,
   actualDays,
-  punishmentType,
 }: NotCompletedForm): FormError | null {
   if (!outcome) {
     return {
@@ -42,12 +40,6 @@ export default function validateForm({
       return {
         href: '#daysToActivate',
         text: `The number of days for the punishment must be ${actualDays} or fewer`,
-      }
-    }
-    if (isSocialVisitsPunishment(punishmentType) && daysToActivate > 28) {
-      return {
-        href: '#daysToActivate',
-        text: 'The number of days for a social visits punishment must be 28 or fewer',
       }
     }
   }

--- a/server/routes/testutils/testData.ts
+++ b/server/routes/testutils/testData.ts
@@ -430,6 +430,7 @@ export default class TestData {
       suspendedUntil: '2023-04-03',
     },
     activatedFrom = '0',
+    hasChildUnder18,
   }: {
     redisId?: string
     id?: number
@@ -439,6 +440,7 @@ export default class TestData {
     stoppagePercentage?: number
     schedule?: PunishmentSchedule
     activatedFrom?: string
+    hasChildUnder18?: boolean
   }): PunishmentDataWithSchedule => {
     return {
       id,
@@ -449,6 +451,7 @@ export default class TestData {
       stoppagePercentage,
       schedule,
       activatedFrom,
+      ...(hasChildUnder18 !== undefined && { hasChildUnder18 }),
       rehabilitativeActivities: [],
     }
   }

--- a/server/services/punishmentsService.test.ts
+++ b/server/services/punishmentsService.test.ts
@@ -264,8 +264,8 @@ describe('PunishmentsService', () => {
       )
     })
   })
-  describe('checkAdditionalDaysAvailability', () => {
-    it('returns false if there are no hearings present on the adjudication', async () => {
+  describe('getPunishmentAvailability', () => {
+    it('returns adult availability when there are no hearings present on the adjudication', async () => {
       getReportedAdjudication.mockResolvedValue({
         reportedAdjudication: testData.reportedAdjudication({
           chargeNumber: '100',
@@ -273,8 +273,8 @@ describe('PunishmentsService', () => {
           status: ReportedAdjudicationStatus.CHARGE_PROVED,
         }),
       })
-      const result = await service.checkAdditionalDaysAvailability('100', user)
-      expect(result).toEqual(false)
+      const result = await service.getPunishmentAvailability('100', user)
+      expect(result).toEqual({ isIndependentAdjudicatorHearing: false, socialVisitsAvailable: true })
     })
     it('returns false if the last hearing on the adjudication is a governor hearing', async () => {
       getReportedAdjudication.mockResolvedValue({
@@ -291,8 +291,8 @@ describe('PunishmentsService', () => {
           ],
         }),
       })
-      const result = await service.checkAdditionalDaysAvailability('100', user)
-      expect(result).toEqual(false)
+      const result = await service.getPunishmentAvailability('100', user)
+      expect(result).toEqual({ isIndependentAdjudicatorHearing: false, socialVisitsAvailable: true })
     })
     it('returns true if the last hearing on the adjudication is an independent adjudicator hearing', async () => {
       getReportedAdjudication.mockResolvedValue({
@@ -309,8 +309,20 @@ describe('PunishmentsService', () => {
           ],
         }),
       })
-      const result = await service.checkAdditionalDaysAvailability('100', user)
-      expect(result).toEqual(true)
+      const result = await service.getPunishmentAvailability('100', user)
+      expect(result).toEqual({ isIndependentAdjudicatorHearing: true, socialVisitsAvailable: true })
+    })
+    it('does not make social visits punishments available for a YOI adjudication', async () => {
+      getReportedAdjudication.mockResolvedValue({
+        reportedAdjudication: testData.reportedAdjudication({
+          chargeNumber: '100',
+          prisonerNumber: 'G6123VU',
+          status: ReportedAdjudicationStatus.CHARGE_PROVED,
+          isYouthOffender: true,
+        }),
+      })
+      const result = await service.getPunishmentAvailability('100', user)
+      expect(result).toEqual({ isIndependentAdjudicatorHearing: false, socialVisitsAvailable: false })
     })
   })
   describe('formatPunishmentComments', () => {

--- a/server/services/punishmentsService.ts
+++ b/server/services/punishmentsService.ts
@@ -41,7 +41,6 @@ export interface ActivityDetails {
   daysToActivate?: number
   suspendedUntil?: string
   actualDays: number
-  punishmentType?: PunishmentType
 }
 
 export default class PunishmentsService {
@@ -374,7 +373,6 @@ export default class PunishmentsService {
       daysToActivate: completedSessionData?.daysToActivate,
       suspendedUntil: completedSessionData?.suspendedUntil,
       actualDays: punishment.schedule.duration,
-      punishmentType: punishment.type,
     }
   }
 

--- a/server/services/punishmentsService.ts
+++ b/server/services/punishmentsService.ts
@@ -41,6 +41,7 @@ export interface ActivityDetails {
   daysToActivate?: number
   suspendedUntil?: string
   actualDays: number
+  punishmentType?: PunishmentType
 }
 
 export default class PunishmentsService {
@@ -373,6 +374,7 @@ export default class PunishmentsService {
       daysToActivate: completedSessionData?.daysToActivate,
       suspendedUntil: completedSessionData?.suspendedUntil,
       actualDays: punishment.schedule.duration,
+      punishmentType: punishment.type,
     }
   }
 
@@ -438,11 +440,16 @@ export default class PunishmentsService {
     return new ManageAdjudicationsUserTokensClient(user).removePunishmentComment(chargeNumber, id)
   }
 
-  async checkAdditionalDaysAvailability(chargeNumber: string, user: User): Promise<boolean> {
+  async getPunishmentAvailability(
+    chargeNumber: string,
+    user: User,
+  ): Promise<{ isIndependentAdjudicatorHearing: boolean; socialVisitsAvailable: boolean }> {
     const reportedAdjudication = await this.getReportedAdjudication(chargeNumber, user)
-    if (!reportedAdjudication.hearings?.length) return false
-    const lastHearing = reportedAdjudication.hearings[reportedAdjudication.hearings.length - 1]
-    return lastHearing.oicHearingType.includes('INAD')
+    const lastHearing = reportedAdjudication.hearings?.[reportedAdjudication.hearings.length - 1]
+    return {
+      isIndependentAdjudicatorHearing: lastHearing?.oicHearingType.includes('INAD') || false,
+      socialVisitsAvailable: !reportedAdjudication.isYouthOffender,
+    }
   }
 
   async getPrisonerDetails(chargeNumber: string, user: User): Promise<PrisonerResult & { friendlyName: string }> {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -390,6 +390,10 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
           return 'Removal from wing or unit'
         case PunishmentType.PAYBACK:
           return 'Payback punishment'
+        case PunishmentType.RESTRICTION_OF_SOCIAL_VISITS:
+          return 'Restriction of social visits'
+        case PunishmentType.LOSS_OF_SOCIAL_VISITS:
+          return 'Loss of social visits'
         default:
           return null
       }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -36,6 +36,7 @@ import {
   convertPrivilegeDTypeDescriptionForDIS7Suspended,
   convertPrivilegeTypeForDIS7,
   convertPunishmentType,
+  isSocialVisitsPunishment,
   NotCompletedOutcome,
   PrivilegeType,
   PunishmentData,
@@ -529,6 +530,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('convertHearingOutcomeFinding', convertHearingOutcomeFinding)
   njkEnv.addFilter('reportedAdjudicationStatusDisplayName', reportedAdjudicationStatusDisplayName)
   njkEnv.addFilter('convertPunishmentType', convertPunishmentType)
+  njkEnv.addFilter('isSocialVisitsPunishment', isSocialVisitsPunishment)
   njkEnv.addFilter('toUpperCase', (input: string) => input.replace(/\b\w/g, match => match.toUpperCase()))
   njkEnv.addFilter('convertNotCompletedOutcome', convertNotCompletedOutcome)
   njkEnv.addGlobal('IssueStatus', IssueStatus)

--- a/server/views/macros/activateSuspendedPunishmentsTable.njk
+++ b/server/views/macros/activateSuspendedPunishmentsTable.njk
@@ -8,6 +8,9 @@
       {% set activateButton = '<button type="submit" name="activate"  value="activate-punishment-'+sanction.id+'" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" data-qa="activate-button" >Activate</button>' %}
 
     {% set typeColumnValue = sanction.type | convertPunishmentType(sanction.stoppagePercentage, sanction.privilegeType, sanction.otherPrivilege) %}
+    {% if sanction.type === PunishmentType.LOSS_OF_SOCIAL_VISITS or sanction.type === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS %}
+      {% set typeColumnValue = typeColumnValue + '<br><span class="govuk-body-s">Children under 18: ' + ('Yes' if sanction.hasChildUnder18 else 'No') + '</span>' %}
+    {% endif %}
 
     {% set rows = (rows.push(
       [

--- a/server/views/macros/activateSuspendedPunishmentsTable.njk
+++ b/server/views/macros/activateSuspendedPunishmentsTable.njk
@@ -8,7 +8,7 @@
       {% set activateButton = '<button type="submit" name="activate"  value="activate-punishment-'+sanction.id+'" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0" data-module="govuk-button" data-qa="activate-button" >Activate</button>' %}
 
     {% set typeColumnValue = sanction.type | convertPunishmentType(sanction.stoppagePercentage, sanction.privilegeType, sanction.otherPrivilege) %}
-    {% if sanction.type === PunishmentType.LOSS_OF_SOCIAL_VISITS or sanction.type === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS %}
+    {% if sanction.type | isSocialVisitsPunishment %}
       {% set typeColumnValue = typeColumnValue + '<br><span class="govuk-body-s">Children under 18: ' + ('Yes' if sanction.hasChildUnder18 else 'No') + '</span>' %}
     {% endif %}
 

--- a/server/views/macros/autoPunishmentScheduleSummary.njk
+++ b/server/views/macros/autoPunishmentScheduleSummary.njk
@@ -41,7 +41,7 @@
       value: {
         text: duration
       },
-    actions: daysChangeLink
+    actions: daysChangeLink if daysChangeHref
     },
     {
       key: {

--- a/server/views/macros/awardPunishmentsTable.njk
+++ b/server/views/macros/awardPunishmentsTable.njk
@@ -8,6 +8,9 @@
     {% set punishmentLockedForRemove = data.canRemove === false %}
 
     {% set typeColumnValue = data.type | convertPunishmentType(data.stoppagePercentage, data.privilegeType, data.otherPrivilege) %}
+    {% if data.type === PunishmentType.LOSS_OF_SOCIAL_VISITS or data.type === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS %}
+      {% set typeColumnValue = typeColumnValue + '<br><span class="govuk-body-s">Children under 18: ' + ('Yes' if data.hasChildUnder18 else 'No') + '</span>' %}
+    {% endif %}
 
     {% set removeColumnValue = '<p class="govuk-body govuk-!-margin-bottom-1"><a href="'+redirectAfterRemoveUrl+redisId+'" data-qa="delete-punishment" class="govuk-link">Remove <span class="govuk-visually-hidden">' + typeColumnValue + '</span></a></p>' %}
 

--- a/server/views/macros/awardPunishmentsTable.njk
+++ b/server/views/macros/awardPunishmentsTable.njk
@@ -8,7 +8,7 @@
     {% set punishmentLockedForRemove = data.canRemove === false %}
 
     {% set typeColumnValue = data.type | convertPunishmentType(data.stoppagePercentage, data.privilegeType, data.otherPrivilege) %}
-    {% if data.type === PunishmentType.LOSS_OF_SOCIAL_VISITS or data.type === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS %}
+    {% if data.type | isSocialVisitsPunishment %}
       {% set typeColumnValue = typeColumnValue + '<br><span class="govuk-body-s">Children under 18: ' + ('Yes' if data.hasChildUnder18 else 'No') + '</span>' %}
     {% endif %}
 

--- a/server/views/macros/punishmentRadios.njk
+++ b/server/views/macros/punishmentRadios.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro punishmentRadios(punishmentType, privilegeType, otherPrivilege, stoppagePercentage, damagesOwedAmount, isIndependentAdjudicatorHearing, damagesUnavailable, cautionUnavailable, errors, title) %}
+{% macro punishmentRadios(punishmentType, privilegeType, otherPrivilege, stoppagePercentage, damagesOwedAmount, hasChildUnder18, isIndependentAdjudicatorHearing, socialVisitsAvailable, damagesUnavailable, cautionUnavailable, errors, title) %}
   {% set otherPrivilegeHtml %}
   {{ govukInput({
       id: "otherPrivilege",
@@ -13,6 +13,58 @@
       label: {
         text: "Privilege to be withdrawn"
       }
+    }) }}
+  {% endset -%}
+
+  {% set lossHasChildUnder18Html %}
+    {{ govukRadios({
+      idPrefix: 'lossHasChildUnder18',
+      name: 'lossHasChildUnder18',
+      fieldset: {
+        legend: {
+          text: 'Does the prisoner have any children under 18?',
+          classes: 'govuk-!-font-weight-regular'
+        }
+      },
+      errorMessage: 'lossHasChildUnder18' | findError(errors),
+      items: [
+        {
+          value: 'true',
+          text: 'Yes',
+          checked: punishmentType == 'LOSS_OF_SOCIAL_VISITS' and hasChildUnder18 === true
+        },
+        {
+          value: 'false',
+          text: 'No',
+          checked: punishmentType == 'LOSS_OF_SOCIAL_VISITS' and hasChildUnder18 === false
+        }
+      ]
+    }) }}
+  {% endset -%}
+
+  {% set restrictionHasChildUnder18Html %}
+    {{ govukRadios({
+      idPrefix: 'restrictionHasChildUnder18',
+      name: 'restrictionHasChildUnder18',
+      fieldset: {
+        legend: {
+          text: 'Does the prisoner have any children under 18?',
+          classes: 'govuk-!-font-weight-regular'
+        }
+      },
+      errorMessage: 'restrictionHasChildUnder18' | findError(errors),
+      items: [
+        {
+          value: 'true',
+          text: 'Yes',
+          checked: punishmentType == 'RESTRICTION_OF_SOCIAL_VISITS' and hasChildUnder18 === true
+        },
+        {
+          value: 'false',
+          text: 'No',
+          checked: punishmentType == 'RESTRICTION_OF_SOCIAL_VISITS' and hasChildUnder18 === false
+        }
+      ]
     }) }}
   {% endset -%}
 
@@ -110,7 +162,28 @@
       conditional: {
         html: privilegeHtml
       }
+    }
+  ] %}
+
+  {% if socialVisitsAvailable %}
+    {% set radioButtonItems = (radioButtonItems.push({
+      value: 'LOSS_OF_SOCIAL_VISITS',
+      text: 'Loss of social visits',
+      checked: punishmentType == 'LOSS_OF_SOCIAL_VISITS',
+      conditional: {
+        html: lossHasChildUnder18Html
+      }
     }, {
+      value: 'RESTRICTION_OF_SOCIAL_VISITS',
+      text: 'Restriction of social visits',
+      checked: punishmentType == 'RESTRICTION_OF_SOCIAL_VISITS',
+      conditional: {
+        html: restrictionHasChildUnder18Html
+      }
+    }), radioButtonItems) %}
+  {% endif %}
+
+  {% set radioButtonItems = (radioButtonItems.push({
       value: "EARNINGS",
       text: "Stoppage of earnings",
       checked: punishmentType == 'EARNINGS',
@@ -140,8 +213,7 @@
       value: "REMOVAL_WING",
       text: "Removal from wing or unit",
       checked: punishmentType == 'REMOVAL_WING'
-    }
-  ] %}
+    }), radioButtonItems) %}
 
   {% set radioButtonItems = (radioButtonItems.push({
       value: "PAYBACK",

--- a/server/views/pages/autoPunishmentSchedule.njk
+++ b/server/views/pages/autoPunishmentSchedule.njk
@@ -28,7 +28,7 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         <h2 class="govuk-heading-m" data-qa="punishment-name">{{ type | convertPunishmentType(stoppagePercentage, privilegeType, otherPrivilege) }}</h2>
-        {% if type === PunishmentType.LOSS_OF_SOCIAL_VISITS or type === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS %}
+        {% if type | isSocialVisitsPunishment %}
           <p class="govuk-body" data-qa="has-child-under-18"><strong>Prisoner has children under 18:</strong> {{ 'Yes' if hasChildUnder18 else 'No' }}</p>
         {% endif %}
         {{ autoPunishmentScheduleSummary(startDate, duration, endDate, startDateChangeHref, daysChangeHref) }}

--- a/server/views/pages/autoPunishmentSchedule.njk
+++ b/server/views/pages/autoPunishmentSchedule.njk
@@ -28,6 +28,9 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         <h2 class="govuk-heading-m" data-qa="punishment-name">{{ type | convertPunishmentType(stoppagePercentage, privilegeType, otherPrivilege) }}</h2>
+        {% if type === PunishmentType.LOSS_OF_SOCIAL_VISITS or type === PunishmentType.RESTRICTION_OF_SOCIAL_VISITS %}
+          <p class="govuk-body" data-qa="has-child-under-18"><strong>Prisoner has children under 18:</strong> {{ 'Yes' if hasChildUnder18 else 'No' }}</p>
+        {% endif %}
         {{ autoPunishmentScheduleSummary(startDate, duration, endDate, startDateChangeHref, daysChangeHref) }}
 
         <div class="govuk-button-group">

--- a/server/views/pages/punishment.njk
+++ b/server/views/pages/punishment.njk
@@ -26,7 +26,7 @@
   <div>
     <form method="POST" novalidate="novalidate" class="govuk-!-margin-top-5">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-      {{ punishmentRadios(punishmentType, privilegeType, otherPrivilege, stoppagePercentage, amount, isIndependentAdjudicatorHearing, damagesUnavailable, cautionUnavailable, errors, title) }}
+      {{ punishmentRadios(punishmentType, privilegeType, otherPrivilege, stoppagePercentage, damagesOwedAmount, hasChildUnder18, isIndependentAdjudicatorHearing, socialVisitsAvailable, damagesUnavailable, cautionUnavailable, errors, title) }}
       <div class="govuk-button-group">
         {{ govukButton({
               text: 'Continue',

--- a/server/views/pages/punishment.njk
+++ b/server/views/pages/punishment.njk
@@ -26,7 +26,7 @@
   <div>
     <form method="POST" novalidate="novalidate" class="govuk-!-margin-top-5">
       <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-      {{ punishmentRadios(punishmentType, privilegeType, otherPrivilege, stoppagePercentage, damagesOwedAmount, hasChildUnder18, isIndependentAdjudicatorHearing, socialVisitsAvailable, damagesUnavailable, cautionUnavailable, errors, title) }}
+      {{ punishmentRadios(punishmentType, privilegeType, otherPrivilege, stoppagePercentage, amount, hasChildUnder18, isIndependentAdjudicatorHearing, socialVisitsAvailable, damagesUnavailable, cautionUnavailable, errors, title) }}
       <div class="govuk-button-group">
         {{ govukButton({
               text: 'Continue',


### PR DESCRIPTION
### Summary

Adds support for the new Adult Rule 51 social-visits punishments:

- Adds `Loss of social visits` and `Restriction of social visits` as separate punishment options
- Makes both options available for adult adjudications only
- Requires the user to record whether the prisoner has children under 18
- Preserves the Yes/No answer throughout create, edit, suspension and activation journeys
- Enforces the policy limits:
  - Loss of social visits: 27 days
  - Restriction of social visits: 84 days
- Displays the required validation messages when these limits are exceeded
- Keeps the invalid duration available for correction
- Calculates and displays the inclusive Last Day from the selected start date and duration
- Displays the child-under-18 answer in punishment summaries and tables
- Preserves existing behaviour for non-visits punishments