### PR TITLE
IR-1785 Restrict prisoner adjudication data to the user's own caseloads

### DIFF
--- a/server/routes/activePunishments/activePunishments.test.ts
+++ b/server/routes/activePunishments/activePunishments.test.ts
@@ -59,4 +59,42 @@ describe('GET /active-punishments', () => {
         expect(response.text).toContain('James Smith’s active punishments')
       })
   })
+
+  it('should load the details for a prisoner in a non-active caseload the user holds', () => {
+    reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+      testData.prisonerResultSummary({
+        offenderNo: 'G7234VB',
+        firstName: 'James',
+        lastName: 'Smith',
+        agencyId: 'LEI',
+      }),
+    )
+
+    return request(app)
+      .get(adjudicationUrls.activePunishments.urls.start('G7234VB'))
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('James Smith’s active punishments')
+      })
+  })
+
+  it('should not show punishments for a prisoner outside the users caseloads', () => {
+    reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+      testData.prisonerResultSummary({
+        offenderNo: 'G7234VB',
+        firstName: 'James',
+        lastName: 'Smith',
+        agencyId: 'BXI',
+      }),
+    )
+
+    return request(app)
+      .get(adjudicationUrls.activePunishments.urls.start('G7234VB'))
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('James Smith')
+        expect(punishmentsService.getActivePunishmentsByOffender).not.toHaveBeenCalled()
+      })
+  })
 })

--- a/server/routes/activePunishments/activePunishments.ts
+++ b/server/routes/activePunishments/activePunishments.ts
@@ -4,12 +4,20 @@ import { PrisonerResultSummary } from '../../services/placeOnReportService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import { ActivePunishment } from '../../data/PunishmentResult'
 import PunishmentsService from '../../services/punishmentsService'
+import { prisonerIsInUsersCaseloads } from '../../utils/caseloadHelper'
 
 export default class ActivePunishmentsRoutes {
   constructor(
     private readonly reportedAdjudicationsService: ReportedAdjudicationsService,
     private readonly punishmentsService: PunishmentsService,
   ) {}
+
+  private renderForbiddenView = async (req: Request, res: Response): Promise<void> => {
+    res.render(`pages/activePunishments.njk`, {
+      prisonerNumber: req.params.prisonerNumber,
+      forbidden: true,
+    })
+  }
 
   private renderView = async (
     req: Request,
@@ -29,6 +37,11 @@ export default class ActivePunishmentsRoutes {
     const { prisonerNumber } = req.params
     const { user } = res.locals
     const prisoner = await this.reportedAdjudicationsService.getPrisonerDetails(prisonerNumber, user)
+
+    if (!prisonerIsInUsersCaseloads(prisoner.agencyId, user)) {
+      return this.renderForbiddenView(req, res)
+    }
+
     const punishments = await this.punishmentsService.getActivePunishmentsByOffender(prisoner.bookingId, user)
     return this.renderView(req, res, prisoner, punishments)
   }

--- a/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.test.ts
+++ b/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.test.ts
@@ -1,0 +1,110 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes from '../testutils/appSetup'
+import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
+import DecisionTreeService from '../../services/decisionTreeService'
+import PunishmentsService from '../../services/punishmentsService'
+import adjudicationUrls from '../../utils/urlGenerator'
+import TestData from '../testutils/testData'
+
+jest.mock('../../services/reportedAdjudicationsService.ts')
+jest.mock('../../services/decisionTreeService.ts')
+jest.mock('../../services/punishmentsService.ts')
+
+const testData = new TestData()
+const reportedAdjudicationsService = new ReportedAdjudicationsService(
+  null,
+  null,
+  null,
+  null,
+  null,
+) as jest.Mocked<ReportedAdjudicationsService>
+const decisionTreeService = new DecisionTreeService(null, null, null, null, null) as jest.Mocked<DecisionTreeService>
+const punishmentsService = new PunishmentsService(null, null) as jest.Mocked<PunishmentsService>
+
+let app: Express
+
+const url = adjudicationUrls.prisonerReportConsolidated.urls.view('G7234VB', 'MDI-100001')
+
+beforeEach(() => {
+  app = appWithAllRoutes(
+    { production: false },
+    { reportedAdjudicationsService, decisionTreeService, punishmentsService },
+  )
+
+  reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+    testData.prisonerResultSummary({
+      offenderNo: 'G7234VB',
+      firstName: 'James',
+      lastName: 'Smith',
+    }),
+  )
+  reportedAdjudicationsService.getReportedAdjudicationDetails.mockResolvedValue({
+    reportedAdjudication: testData.reportedAdjudication({
+      chargeNumber: 'MDI-100001',
+      prisonerNumber: 'G7234VB',
+    }),
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET consolidated adjudication view - caseload restrictions', () => {
+  it('should not show the adjudication for a prisoner outside the users caseloads', () => {
+    reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+      testData.prisonerResultSummary({
+        offenderNo: 'G7234VB',
+        firstName: 'James',
+        lastName: 'Smith',
+        agencyId: 'BXI',
+      }),
+    )
+
+    return request(app)
+      .get(url)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('MDI-100001')
+        expect(reportedAdjudicationsService.getReportedAdjudicationDetails).not.toHaveBeenCalled()
+      })
+  })
+
+  it('should not let the agency query parameter grant access to a prisoner outside the users caseloads', () => {
+    reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+      testData.prisonerResultSummary({
+        offenderNo: 'G7234VB',
+        firstName: 'James',
+        lastName: 'Smith',
+        agencyId: 'BXI',
+      }),
+    )
+
+    return request(app)
+      .get(`${url}?agency=BXI`)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(reportedAdjudicationsService.getReportedAdjudicationDetails).not.toHaveBeenCalled()
+      })
+  })
+
+  it('should not show an adjudication belonging to a different prisoner', () => {
+    reportedAdjudicationsService.getReportedAdjudicationDetails.mockResolvedValue({
+      reportedAdjudication: testData.reportedAdjudication({
+        chargeNumber: 'MDI-100001',
+        prisonerNumber: 'A1234AA',
+      }),
+    })
+
+    return request(app)
+      .get(url)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('Adjudication for charge MDI-100001')
+      })
+  })
+})

--- a/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.ts
+++ b/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 import ReportedAdjudicationsService, { ConvertedEvidence } from '../../services/reportedAdjudicationsService'
-import UserService from '../../services/userService'
 import { PrisonerResultSummary } from '../../services/placeOnReportService'
 import DecisionTreeService, { IncidentAndOffences } from '../../services/decisionTreeService'
 import { ReportedAdjudication, ReportedAdjudicationStatus } from '../../data/ReportedAdjudicationResult'
@@ -14,7 +13,7 @@ import {
   PunishmentDataWithSchedule,
   flattenPunishments,
 } from '../../data/PunishmentResult'
-import { hasAnyRole } from '../../utils/utils'
+import { prisonerIsInUsersCaseloads } from '../../utils/caseloadHelper'
 
 type PageData = {
   prisoner: PrisonerResultSummary
@@ -42,16 +41,21 @@ type PageData = {
   quashed: boolean
   chargeProved: boolean
   corrupted: boolean
-  forbidden?: boolean
 }
 
 export default class AdjudicationConsolidatedView {
   constructor(
     private readonly reportedAdjudicationsService: ReportedAdjudicationsService,
-    private readonly userService: UserService,
     private readonly decisionTreeService: DecisionTreeService,
     private readonly punishmentsService: PunishmentsService,
   ) {}
+
+  private renderForbiddenView = async (res: Response, prisoner: PrisonerResultSummary): Promise<void> => {
+    res.render(`pages/adjudicationConsolidatedView.njk`, {
+      prisonerNumber: prisoner.prisonerNumber,
+      forbidden: true,
+    })
+  }
 
   private renderView = async (req: Request, res: Response, pageData: PageData): Promise<void> => {
     const {
@@ -70,7 +74,6 @@ export default class AdjudicationConsolidatedView {
       quashed,
       chargeProved,
       corrupted,
-      forbidden,
     } = pageData
     res.render(`pages/adjudicationConsolidatedView.njk`, {
       prisonerNumber: prisoner.prisonerNumber,
@@ -91,7 +94,6 @@ export default class AdjudicationConsolidatedView {
       quashed,
       chargeProved,
       corrupted,
-      forbidden,
     })
   }
 
@@ -99,21 +101,23 @@ export default class AdjudicationConsolidatedView {
     const { chargeNumber, prisonerNumber } = req.params
     const { user } = res.locals
     const activeCaseLoadId = req.query.agency as string
-    let forbidden = false
 
     const prisoner = await this.reportedAdjudicationsService.getPrisonerDetails(prisonerNumber, user)
+
+    // The agency query param becomes the API's Active-Caseload header, so it must not be trusted
+    // until we know the prisoner belongs to this user, and that the charge belongs to the prisoner.
+    if (!prisonerIsInUsersCaseloads(prisoner.agencyId, user)) {
+      return this.renderForbiddenView(res, prisoner)
+    }
+
     const { reportedAdjudication } = await this.reportedAdjudicationsService.getReportedAdjudicationDetails(
       chargeNumber,
       user,
       activeCaseLoadId,
     )
 
-    if (prisoner.agencyId !== user.meta.caseLoadId) {
-      const userRoles = await this.userService.getUserRoles(user.token)
-      forbidden = !hasAnyRole(['GLOBAL_SEARCH'], userRoles)
-    }
     if (prisoner.prisonerNumber !== reportedAdjudication.prisonerNumber) {
-      forbidden = true
+      return this.renderForbiddenView(res, prisoner)
     }
 
     const { reviewData, evidence, offence, prisonerReportDetails, transferBannerInfo } = await this.getInfoForReport(
@@ -142,7 +146,6 @@ export default class AdjudicationConsolidatedView {
       quashed,
       chargeProved,
       corrupted,
-      forbidden,
     })
   }
 

--- a/server/routes/adjudicationConsolidatedView/index.ts
+++ b/server/routes/adjudicationConsolidatedView/index.ts
@@ -3,19 +3,16 @@ import express, { RequestHandler, Router } from 'express'
 import AdjudicationConsolidatedView from './adjudicationConsolidatedView'
 
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
-import UserService from '../../services/userService'
 import DecisionTreeService from '../../services/decisionTreeService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import PunishmentsService from '../../services/punishmentsService'
 
 export default function adjudicationConsolidatedViewRoutes({
   reportedAdjudicationsService,
-  userService,
   decisionTreeService,
   punishmentsService,
 }: {
   reportedAdjudicationsService: ReportedAdjudicationsService
-  userService: UserService
   decisionTreeService: DecisionTreeService
   punishmentsService: PunishmentsService
 }): Router {
@@ -23,7 +20,6 @@ export default function adjudicationConsolidatedViewRoutes({
 
   const adjudicationConsolidatedViewRoute = new AdjudicationConsolidatedView(
     reportedAdjudicationsService,
-    userService,
     decisionTreeService,
     punishmentsService,
   )

--- a/server/routes/adjudicationHistory/adjudicationHistory.test.ts
+++ b/server/routes/adjudicationHistory/adjudicationHistory.test.ts
@@ -92,6 +92,46 @@ describe('GET /adjudication-history', () => {
         expect(response.text).toContain('Happened at: Moorland (HMP)')
       })
   })
+
+  it('should load the history for a prisoner in a non-active caseload the user holds', () => {
+    reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+      testData.prisonerResultSummary({
+        offenderNo: 'G7234VB',
+        firstName: 'James',
+        lastName: 'Smith',
+        agencyId: 'LEI',
+      }),
+    )
+
+    return request(app)
+      .get(adjudicationUrls.adjudicationHistory.urls.start('G7234VB'))
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('James Smith’s adjudication history')
+        expect(response.text).toContain('MDI-100001')
+      })
+  })
+
+  it('should not show the history for a prisoner outside the users caseloads', () => {
+    reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+      testData.prisonerResultSummary({
+        offenderNo: 'G7234VB',
+        firstName: 'James',
+        lastName: 'Smith',
+        agencyId: 'BXI',
+      }),
+    )
+
+    return request(app)
+      .get(adjudicationUrls.adjudicationHistory.urls.start('G7234VB'))
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('MDI-100001')
+        expect(reportedAdjudicationsService.getAdjudicationHistory).not.toHaveBeenCalled()
+        expect(reportedAdjudicationsService.getUniqueListOfAgenciesForPrisoner).not.toHaveBeenCalled()
+      })
+  })
 })
 
 describe('POST /adjudication-history', () => {

--- a/server/routes/adjudicationHistory/adjudicationHistory.ts
+++ b/server/routes/adjudicationHistory/adjudicationHistory.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import mojPaginationFromPageResponse, { pageRequestFrom } from '../../utils/mojPagination/pagination'
-import { formatDateForDatePicker, hasAnyRole } from '../../utils/utils'
+import { formatDateForDatePicker } from '../../utils/utils'
 import { ReportedAdjudication } from '../../data/ReportedAdjudicationResult'
 import { ApiPageResponse } from '../../data/ApiData'
 import adjudicationUrls from '../../utils/urlGenerator'
@@ -18,13 +18,17 @@ import {
 import { EstablishmentInformation, FormError } from '../../@types/template'
 import { PrisonerResultSummary } from '../../services/placeOnReportService'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
-import UserService from '../../services/userService'
+import { prisonerIsInUsersCaseloads } from '../../utils/caseloadHelper'
 
 export default class AdjudicationHistoryRoutes {
-  constructor(
-    private readonly reportedAdjudicationsService: ReportedAdjudicationsService,
-    private readonly userService: UserService,
-  ) {}
+  constructor(private readonly reportedAdjudicationsService: ReportedAdjudicationsService) {}
+
+  private renderForbiddenView = async (req: Request, res: Response): Promise<void> => {
+    res.render(`pages/adjudicationHistory.njk`, {
+      prisonerNumber: req.params.prisonerNumber,
+      forbidden: true,
+    })
+  }
 
   private renderView = async (
     req: Request,
@@ -34,7 +38,6 @@ export default class AdjudicationHistoryRoutes {
     errors: FormError[],
     prisoner: PrisonerResultSummary,
     uniqueListOfAgenciesForPrisoner: Array<EstablishmentInformation>,
-    forbidden?: boolean,
   ): Promise<void> => {
     res.render(`pages/adjudicationHistory.njk`, {
       prisonerNumber: req.params.prisonerNumber,
@@ -51,7 +54,6 @@ export default class AdjudicationHistoryRoutes {
       errors,
       maxDate: formatDateForDatePicker(new Date().toISOString(), 'short'),
       uniqueListOfAgenciesForPrisoner,
-      forbidden,
     })
   }
 
@@ -61,12 +63,9 @@ export default class AdjudicationHistoryRoutes {
     const uiFilter = fillInAdjudicationHistoryDefaults(uiAdjudicationHistoryFilterFromRequest(req))
     const filter = adjudicationHistoryFilterFromUiFilter(uiFilter)
     const prisoner = await this.reportedAdjudicationsService.getPrisonerDetails(prisonerNumber, user)
-    const activeCaseLoadId = user.meta.caseLoadId
-    let forbidden = false
 
-    if (prisoner.agencyId !== activeCaseLoadId) {
-      const roles = await this.userService.getUserRoles(user.token)
-      forbidden = !hasAnyRole(['GLOBAL_SEARCH'], roles)
+    if (!prisonerIsInUsersCaseloads(prisoner.agencyId, user)) {
+      return this.renderForbiddenView(req, res)
     }
 
     const uniqueListOfAgenciesForPrisoner = await this.reportedAdjudicationsService.getUniqueListOfAgenciesForPrisoner(
@@ -80,7 +79,7 @@ export default class AdjudicationHistoryRoutes {
       pageRequestFrom(20, +req.query.pageNumber || 1),
       res.locals.user,
     )
-    return this.renderView(req, res, uiFilter, results, [], prisoner, uniqueListOfAgenciesForPrisoner, forbidden)
+    return this.renderView(req, res, uiFilter, results, [], prisoner, uniqueListOfAgenciesForPrisoner)
   }
 
   submit = async (req: Request, res: Response): Promise<void> => {
@@ -90,6 +89,11 @@ export default class AdjudicationHistoryRoutes {
     const errors = validate(uiFilter)
     if (errors && errors.length !== 0) {
       const prisoner = await this.reportedAdjudicationsService.getPrisonerDetails(prisonerNumber, user)
+
+      if (!prisonerIsInUsersCaseloads(prisoner.agencyId, user)) {
+        return this.renderForbiddenView(req, res)
+      }
+
       const uniqueListOfAgenciesForPrisoner =
         await this.reportedAdjudicationsService.getUniqueListOfAgenciesForPrisoner(prisonerNumber, user)
       return this.renderView(

--- a/server/routes/adjudicationHistory/index.ts
+++ b/server/routes/adjudicationHistory/index.ts
@@ -4,18 +4,15 @@ import AdjudicationHistory from './adjudicationHistory'
 
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import adjudicationUrls from '../../utils/urlGenerator'
-import UserService from '../../services/userService'
 
 export default function adjudicationHistoryRoutes({
   reportedAdjudicationsService,
-  userService,
 }: {
   reportedAdjudicationsService: ReportedAdjudicationsService
-  userService: UserService
 }): Router {
   const router = express.Router()
 
-  const adjudicationHistoryRoute = new AdjudicationHistory(reportedAdjudicationsService, userService)
+  const adjudicationHistoryRoute = new AdjudicationHistory(reportedAdjudicationsService)
 
   const get = (path: string, handler: RequestHandler) => router.get(path, handler)
   const post = (path: string, handler: RequestHandler) => router.post(path, handler)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -510,10 +510,7 @@ export default function routes(
       reportedAdjudicationsService,
     }),
   )
-  router.use(
-    adjudicationUrls.adjudicationHistory.root,
-    adjudicationHistoryRoutes({ reportedAdjudicationsService, userService }),
-  )
+  router.use(adjudicationUrls.adjudicationHistory.root, adjudicationHistoryRoutes({ reportedAdjudicationsService }))
   router.use(
     adjudicationUrls.activePunishments.root,
     activePunishmentsRoutes({ reportedAdjudicationsService, punishmentsService }),
@@ -522,7 +519,6 @@ export default function routes(
     adjudicationUrls.prisonerReportConsolidated.root,
     adjudicationConsolidatedViewRoutes({
       reportedAdjudicationsService,
-      userService,
       decisionTreeService,
       punishmentsService,
     }),

--- a/server/routes/prisonerRoutes.ts
+++ b/server/routes/prisonerRoutes.ts
@@ -1,7 +1,8 @@
 import path from 'path'
-import express, { Router } from 'express'
+import express, { Response, Router } from 'express'
 
 import PlaceOnReportService from '../services/placeOnReportService'
+import { prisonerIsInUsersCaseloads } from '../utils/caseloadHelper'
 
 export default function prisonerRoutes({
   placeOnReportService,
@@ -10,16 +11,29 @@ export default function prisonerRoutes({
 }): Router {
   const router = express.Router()
 
+  const sendPlaceholder = (res: Response) => res.sendFile(path.join(process.cwd(), '/assets/images/image-missing.jpg'))
+
   router.get('/:prisonerNumber/image', async (req, res, next) => {
-    placeOnReportService
-      .getPrisonerImage(req.params.prisonerNumber, res.locals.user)
+    const { prisonerNumber } = req.params
+    const { user } = res.locals
+
+    try {
+      const prisoner = await placeOnReportService.getPrisonerDetails(prisonerNumber, user)
+      if (!prisonerIsInUsersCaseloads(prisoner.agencyId, user)) {
+        return sendPlaceholder(res)
+      }
+    } catch {
+      return sendPlaceholder(res)
+    }
+
+    return placeOnReportService
+      .getPrisonerImage(prisonerNumber, user)
       .then(data => {
         res.type('image/jpeg')
         data.pipe(res)
       })
       .catch(() => {
-        const placeHolder = path.join(process.cwd(), '/assets/images/image-missing.jpg')
-        res.sendFile(placeHolder)
+        sendPlaceholder(res)
       })
   })
 

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -8,7 +8,7 @@ import HmppsManageUsersClient, { NomisUserResult, User } from '../data/hmppsMana
 interface UserDetails {
   name: string
   displayName: string
-  allCaseLoads: CaseLoad[] | string[]
+  allCaseLoads: CaseLoad[]
   activeCaseLoad: CaseLoad
 }
 

--- a/server/utils/caseloadHelper.test.ts
+++ b/server/utils/caseloadHelper.test.ts
@@ -1,0 +1,36 @@
+import { prisonerIsInUsersCaseloads } from './caseloadHelper'
+import { CaseLoad } from '../data/prisonApiClient'
+
+const caseLoad = (caseLoadId: string, currentlyActive = false): CaseLoad => ({
+  caseLoadId,
+  description: caseLoadId,
+  type: 'INST',
+  caseloadFunction: 'TEST',
+  currentlyActive,
+})
+
+describe('prisonerIsInUsersCaseloads', () => {
+  const user = { allCaseLoads: [caseLoad('MDI', true), caseLoad('LEI')] }
+
+  it('allows a prisoner in the users active caseload', () => {
+    expect(prisonerIsInUsersCaseloads('MDI', user)).toBe(true)
+  })
+
+  it('allows a prisoner in a caseload the user holds but is not currently active in', () => {
+    expect(prisonerIsInUsersCaseloads('LEI', user)).toBe(true)
+  })
+
+  it('denies a prisoner in a caseload the user does not hold', () => {
+    expect(prisonerIsInUsersCaseloads('BXI', user)).toBe(false)
+  })
+
+  it('denies a released prisoner with no agency', () => {
+    expect(prisonerIsInUsersCaseloads(null, user)).toBe(false)
+    expect(prisonerIsInUsersCaseloads('', user)).toBe(false)
+  })
+
+  it('denies when the user has no caseloads', () => {
+    expect(prisonerIsInUsersCaseloads('MDI', {})).toBe(false)
+    expect(prisonerIsInUsersCaseloads('MDI', { allCaseLoads: [] })).toBe(false)
+  })
+})

--- a/server/utils/caseloadHelper.ts
+++ b/server/utils/caseloadHelper.ts
@@ -1,0 +1,9 @@
+import { CaseLoad } from '../data/prisonApiClient'
+
+// The adjudications API is called with a system token and told which caseload to act as via the
+// Active-Caseload header, so it cannot police who the user is. Access to a prisoner's adjudication
+// data has to be restricted here, against the caseloads the user actually holds.
+export const prisonerIsInUsersCaseloads = (prisonerAgencyId: string, user: { allCaseLoads?: CaseLoad[] }): boolean =>
+  !!prisonerAgencyId && (user.allCaseLoads || []).some(caseLoad => caseLoad.caseLoadId === prisonerAgencyId)
+
+export default prisonerIsInUsersCaseloads

--- a/server/views/pages/activePunishments.njk
+++ b/server/views/pages/activePunishments.njk
@@ -15,8 +15,8 @@
       href: digitalPrisonServiceUrl
     },
     {
-      text: prisoner.displayName,
-      href: prisonerProfileServiceUrl + '/prisoner/' + prisonerNumber
+      text: 'Adjudications' if forbidden else prisoner.displayName,
+      href: '/place-a-prisoner-on-report' if forbidden else prisonerProfileServiceUrl + '/prisoner/' + prisonerNumber
     }
     ],
     classes: "govuk-!-display-none-print"
@@ -24,6 +24,9 @@
 {% endblock %}
 
 {% block content %}
+  {% if forbidden %}
+    {% include '../partials/forbiddenEstablishment.njk' %}
+  {% else %}
   <h1 class="govuk-heading-l">{{ prisoner.friendlyName | possessive }} active punishments</h1>
   <div>
     {% if punishments | length %}
@@ -36,4 +39,5 @@
       <a href="{{ adjudicationHistoryHref }}" class="govuk-link" data-qa="adjudicationHistory-link">View adjudication history</a>
     </p>
   </div>
+  {% endif %}
 {% endblock %}

--- a/server/views/pages/adjudicationConsolidatedView.njk
+++ b/server/views/pages/adjudicationConsolidatedView.njk
@@ -38,9 +38,7 @@
 {% endblock %}
 {% block content %}
 {% if forbidden %}
-    <h1 class="govuk-heading-l">You do not have permission to view people outside of your establishment.</h1>
-    <p class="govuk-body">You need extra permission to be able to view and create reports for people who are not in your establishment.</p>
-    <p class="govuk-body">Contact a local system administrator (LSA) in your establishment to discuss the permission you need.</p>
+    {% include '../partials/forbiddenEstablishment.njk' %}
 {% else %}
   {# Report details #}
   <div class="govuk-grid-row">

--- a/server/views/pages/adjudicationHistory.njk
+++ b/server/views/pages/adjudicationHistory.njk
@@ -37,9 +37,7 @@
   {% endif %}
 
   {% if forbidden %}
-    <h1 class="govuk-heading-l">You do not have permission to view people outside of your establishment.</h1>
-    <p class="govuk-body">You need extra permission to be able to view and create reports for people who are not in your establishment.</p>
-    <p class="govuk-body">Contact a local system administrator (LSA) in your establishment to discuss the permission you need.</p>
+    {% include '../partials/forbiddenEstablishment.njk' %}
   {% else %}
   <h1 class="govuk-heading-l" data-qa="title">{{ prisoner.friendlyName | possessive }} adjudication history</h1>
 

--- a/server/views/partials/forbiddenEstablishment.njk
+++ b/server/views/partials/forbiddenEstablishment.njk
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-l" data-qa="forbidden">You do not have permission to view people outside of your establishment.</h1>
+<p class="govuk-body">You need extra permission to be able to view and create reports for people who are not in your establishment.</p>
+<p class="govuk-body">Contact a local system administrator (LSA) in your establishment to discuss the permission you need.</p>


### PR DESCRIPTION
## Problem

A user could change the prisoner number in the URL to view the adjudication history, active punishments and individual charges of any offender in the country.

This cannot be fixed in the API. The frontend calls the adjudications API with a **system token** and tells it which caseload to act as via the `Active-Caseload` header, so the API's own check (`ReportedAdjudicationBaseService.findByChargeNumber`) is only as trustworthy as the header we send it. Several prisoner-scoped endpoints (`/booking/{bookingId}`, `/bookings/prisoner/{prisonerNumber}`, `/punishments/{bookingId}/active`) are deliberately cross-agency and do no caseload check at all.

Four gaps:

| Route | Problem |
|---|---|
| `activePunishments` | No check at all — any prisoner's live punishments, nationally |
| `adjudicationConsolidatedView` | The user-supplied `?agency=` query param was passed straight through as the API's `Active-Caseload` header, so the URL author chose which caseload the API validated against |
| `prisonerRoutes` (`/prisoner/:prisonerNumber/image`) | Unguarded prisoner photo |
| `adjudicationHistory` + consolidated view | Had a check from LSM-25, but fetched all the data first and only hid it at render time |

## Changes

- New `prisonerIsInUsersCaseloads` (`server/utils/caseloadHelper.ts`), checking the prisoner's agency against **every** caseload on the user's account rather than only their currently active one.
- All four routes guarded, and the check now runs **before** any data is fetched rather than hiding it in the template.
- The `?agency=` param is retained (it is needed to open a prisoner's historic charges from other establishments) but no longer reaches the API until we know the prisoner is in the user's caseloads *and* the charge belongs to that prisoner.
- Shared "you do not have permission" copy extracted into `server/views/partials/forbiddenEstablishment.njk`.

## ⚠️ Behaviour change — needs sign-off

**Access is no longer granted by the `GLOBAL_SEARCH` role.** Previously anyone with it could view adjudication records for any prisoner nationally. This will affect regional/HQ users, and anyone looking at a prisoner who has transferred to them but whose move has not yet landed in NOMIS.

`GLOBAL_SEARCH` is left untouched on the separate "search for a prisoner to transfer in" flow (`prisonerSearch.ts`).

## Testing

- Full unit suite passes (1172), including 9 new route tests and a 5-case helper suite.
- The new denial tests were confirmed to bite: stubbing the helper to return `true` makes exactly those 4 tests fail.
- 26 Cypress tests across the three affected pages pass.
- Lint and typecheck clean.

Not tested against real NOMIS data, so the `GLOBAL_SEARCH` change has not been exercised with real users' caseloads.

## How to verify manually

1. A prisoner at your active caseload — history, active punishments and a charge all load as before.
2. A prisoner at another caseload on your account, **without** switching active caseload — should also load.
3. A prisoner at a prison not on your account, for each of `/adjudication-history/:prisonerNumber`, `/active-punishments/:prisonerNumber` and `/prisoner-report-consolidated/:prisonerNumber/report/:chargeNumber` — permission message, no prisoner data anywhere in the response body.
4. Append `?agency=<other prison>` to the consolidated view URL for that prisoner — still refused.
