### PR TITLE
IR-1785 Restrict adjudication access using shared prison-permissions library

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
         stubGetUserFromUsername: users.stubGetUserFromUsername,
         stubSearch: prisonerSearch.stubSearch,
         stubSearchPrisonerDetails: prisonerSearch.stubSearchPrisonerDetails,
+        stubGetPrisonerPermissionDetails: prisonerSearch.stubGetPrisonerPermissionDetails,
         stubAuthUser: users.stubAuthUser,
         stubUserOriginatingAgency: users.stubUserOriginatingAgency,
         stubGetUser: users.stubGetUser,

--- a/integration_tests/integration/activePunishments.cy.ts
+++ b/integration_tests/integration/activePunishments.cy.ts
@@ -11,6 +11,7 @@ context('Display active punishments', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubGetPrisonerPermissionDetails')
     cy.task('stubGetUserFromUsername', {
       username: 'USER1',
       response: testData.userFromUsername(),

--- a/integration_tests/integration/adjudicationConsolidatedView.cy.ts
+++ b/integration_tests/integration/adjudicationConsolidatedView.cy.ts
@@ -227,6 +227,7 @@ context('Consolidated report', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubGetPrisonerPermissionDetails')
     cy.task('stubUserOriginatingAgency', 'MDI')
     // Prisoner
     cy.task('stubGetPrisonerDetails', {

--- a/integration_tests/integration/adjudicationHistory.cy.ts
+++ b/integration_tests/integration/adjudicationHistory.cy.ts
@@ -13,6 +13,7 @@ context('Adjudication history', () => {
     cy.task('reset')
     cy.task('stubSignIn', ['NOT_REVIEWER'])
     cy.task('stubAuthUser')
+    cy.task('stubGetPrisonerPermissionDetails')
     cy.task('stubGetPrisonerDetails', {
       prisonerNumber: 'G6415GD',
       response: testData.prisonerResultSummary({

--- a/integration_tests/integration/adjudicationHistory.cy.ts
+++ b/integration_tests/integration/adjudicationHistory.cy.ts
@@ -293,6 +293,7 @@ context('Adjudication history - as ALO', () => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
+    cy.task('stubGetPrisonerPermissionDetails')
     cy.task('stubGetPrisonerDetails', {
       prisonerNumber: 'G6415GD',
       response: testData.prisonerResultSummary({

--- a/integration_tests/mockApis/prisonerSearch.ts
+++ b/integration_tests/mockApis/prisonerSearch.ts
@@ -47,8 +47,25 @@ const stubSearchPrisonerDetails = ({ prisonerNumber, status = 200 }): SuperAgent
     },
   })
 
+// The hmpps-prison-permissions-lib guard looks up the prisoner in prisoner-search (GET /prisoner/{n})
+// using a system token and only reads prisonId / restrictedPatient to decide access, so a catch-all
+// stub returning a prisoner inside the user's caseload (MDI) is enough to let the guarded pages load.
+const stubGetPrisonerPermissionDetails = ({ prisonId = 'MDI', restrictedPatient = false } = {}): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: '/search/prisoner/[A-Za-z0-9]+',
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: { prisonId, restrictedPatient },
+    },
+  })
+
 export default {
   stubPing,
   stubSearch,
   stubSearchPrisonerDetails,
+  stubGetPrisonerPermissionDetails,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@ministryofjustice/frontend": "^9.0.0",
         "@ministryofjustice/hmpps-monitoring": "^2.1.0",
+        "@ministryofjustice/hmpps-prison-permissions-lib": "4.2.0",
+        "@ministryofjustice/hmpps-rest-client": "2.2.0",
         "@types/jsonwebtoken": "^9.0.10",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^3.15.0",
@@ -2270,10 +2272,22 @@
         "node": "22 || 24 || 26"
       }
     },
+    "node_modules/@ministryofjustice/hmpps-prison-permissions-lib": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-prison-permissions-lib/-/hmpps-prison-permissions-lib-4.2.0.tgz",
+      "integrity": "sha512-xN1QGfHOBx96V1adC5tqgKG7vr/Mp7HIhFNQ6jIR3rgJFU42yASBPQEWq9TSYgZ6CD06CnvHfw6zRRn7X7rlww==",
+      "license": "MIT",
+      "dependencies": {
+        "@ministryofjustice/hmpps-rest-client": "2.2.0"
+      },
+      "engines": {
+        "node": "22 || 24 || 26"
+      }
+    },
     "node_modules/@ministryofjustice/hmpps-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-2.1.0.tgz",
-      "integrity": "sha512-Lx2UTbVyVADZees2ikGtpvkErPCLCptr0qCYVQBQ8a2CEUegWXkQ/U6Ia+WiCGODs3CstROGPak7DugWtlm29w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-rest-client/-/hmpps-rest-client-2.2.0.tgz",
+      "integrity": "sha512-sZQ6K47NvtcE4trUGRS85JqVRpBHAteuC8XT0N5qB14TLniNJVvRVoCK6O/gGwT9wQEzLW7C6DW1T6SOFGnTrQ==",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ministryofjustice/frontend": "^9.0.0",
         "@ministryofjustice/hmpps-monitoring": "^2.1.0",
-        "@ministryofjustice/hmpps-prison-permissions-lib": "4.2.0",
+        "@ministryofjustice/hmpps-prison-permissions-lib": "4.1.0",
         "@ministryofjustice/hmpps-rest-client": "2.2.0",
         "@types/jsonwebtoken": "^9.0.10",
         "agentkeepalive": "^4.6.0",
@@ -2273,9 +2273,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-prison-permissions-lib": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-prison-permissions-lib/-/hmpps-prison-permissions-lib-4.2.0.tgz",
-      "integrity": "sha512-xN1QGfHOBx96V1adC5tqgKG7vr/Mp7HIhFNQ6jIR3rgJFU42yASBPQEWq9TSYgZ6CD06CnvHfw6zRRn7X7rlww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-prison-permissions-lib/-/hmpps-prison-permissions-lib-4.1.0.tgz",
+      "integrity": "sha512-WGioGVRbQWnA99VEP+K5VVW8JZTFTVH0YVZAyuQJPUd+tjFFRp3lQbbGMoLQ9QKL7JoLtXJc1CD13TouhdXn9g==",
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/hmpps-rest-client": "2.2.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@ministryofjustice/frontend": "^9.0.0",
     "@ministryofjustice/hmpps-monitoring": "^2.1.0",
-    "@ministryofjustice/hmpps-prison-permissions-lib": "4.2.0",
+    "@ministryofjustice/hmpps-prison-permissions-lib": "4.1.0",
     "@ministryofjustice/hmpps-rest-client": "2.2.0",
     "@types/jsonwebtoken": "^9.0.10",
     "agentkeepalive": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
   "dependencies": {
     "@ministryofjustice/frontend": "^9.0.0",
     "@ministryofjustice/hmpps-monitoring": "^2.1.0",
+    "@ministryofjustice/hmpps-prison-permissions-lib": "4.2.0",
+    "@ministryofjustice/hmpps-rest-client": "2.2.0",
     "@types/jsonwebtoken": "^9.0.10",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^3.15.0",

--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -1,10 +1,18 @@
 import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
+import renderForbidden from './utils/renderForbidden'
 
 export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
     logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
+
+    // The hmpps-prison-permissions-lib guard rejects with a PrisonerPermissionError (403) carrying
+    // deniedPermissionChecks when a user may not see a prisoner. Show the forbidden page rather than
+    // signing them out, which is what the generic 403 branch below would otherwise do.
+    if (Array.isArray((error as unknown as { deniedPermissionChecks?: unknown[] }).deniedPermissionChecks)) {
+      return renderForbidden(res)
+    }
 
     if (error.status === 401 || error.status === 403) {
       logger.info('Logging user out')

--- a/server/middleware/mapUserForPrisonPermissions.test.ts
+++ b/server/middleware/mapUserForPrisonPermissions.test.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from 'express'
+import { jwtDecode } from 'jwt-decode'
+import mapUserForPrisonPermissions from './mapUserForPrisonPermissions'
+
+jest.mock('jwt-decode')
+
+describe('mapUserForPrisonPermissions', () => {
+  const next = jest.fn()
+
+  beforeEach(() => jest.resetAllMocks())
+
+  it('maps the app user onto the shape the permissions library reads', () => {
+    ;(jwtDecode as jest.Mock).mockReturnValue({ authorities: ['ROLE_POM'] })
+    const res = {
+      locals: { user: { token: 'a.b.c', allCaseLoads: [{ caseLoadId: 'MDI' }], meta: { caseLoadId: 'MDI' } } },
+    } as unknown as Response
+
+    mapUserForPrisonPermissions()({} as Request, res, next)
+
+    expect(res.locals.user).toMatchObject({
+      authSource: 'nomis',
+      userRoles: ['ROLE_POM'],
+      caseLoads: [{ caseLoadId: 'MDI' }],
+      activeCaseLoadId: 'MDI',
+    })
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('leaves the user untouched when there is no token', () => {
+    const res = { locals: {} } as unknown as Response
+
+    mapUserForPrisonPermissions()({} as Request, res, next)
+
+    expect(res.locals.user).toBeUndefined()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/middleware/mapUserForPrisonPermissions.ts
+++ b/server/middleware/mapUserForPrisonPermissions.ts
@@ -1,0 +1,27 @@
+import { RequestHandler } from 'express'
+import { jwtDecode } from 'jwt-decode'
+
+/**
+ * hmpps-prison-permissions-lib reads a specific "PrisonUser" shape from res.locals.user:
+ * authSource === 'nomis', caseLoads, activeCaseLoadId and userRoles. This app exposes the same facts
+ * under different names (allCaseLoads, meta.caseLoadId) and decodes roles from the token on demand,
+ * so map them across once here, after populateCurrentUser, for the permission guard/service to read.
+ *
+ * authSource must be 'nomis' or the library's isInUsersCaseLoad ignores caseLoads and denies everyone.
+ */
+export default function mapUserForPrisonPermissions(): RequestHandler {
+  return (req, res, next) => {
+    const { user } = res.locals
+    if (user?.token) {
+      const { authorities: userRoles = [] } = jwtDecode(user.token) as { authorities?: string[] }
+      res.locals.user = {
+        ...user,
+        authSource: 'nomis',
+        userRoles,
+        caseLoads: user.allCaseLoads ?? [],
+        activeCaseLoadId: user.meta?.caseLoadId ?? user.activeCaseLoadId,
+      }
+    }
+    next()
+  }
+}

--- a/server/routes/activePunishments/activePunishments.test.ts
+++ b/server/routes/activePunishments/activePunishments.test.ts
@@ -1,15 +1,21 @@
 import { Express } from 'express'
 import request from 'supertest'
+import { PrisonerAdjudicationsPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import appWithAllRoutes from '../testutils/appSetup'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import TestData from '../testutils/testData'
 import PunishmentsService from '../../services/punishmentsService'
 import { PunishmentMeasurement, PunishmentType } from '../../data/PunishmentResult'
-import { mockPermissionsService } from '../testutils/mockPermissions'
+import mockPermissions from '../testutils/mockPermissions'
 
 jest.mock('../../services/reportedAdjudicationsService.ts')
 jest.mock('../../services/punishmentsService.ts')
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib', () => ({
+  ...jest.requireActual('@ministryofjustice/hmpps-prison-permissions-lib'),
+  isGranted: jest.fn(),
+  prisonerPermissionsGuard: jest.fn(),
+}))
 
 const testData = new TestData()
 const reportedAdjudicationsService = new ReportedAdjudicationsService(
@@ -24,6 +30,7 @@ const punishmentsService = new PunishmentsService(null, null) as jest.Mocked<Pun
 let app: Express
 
 beforeEach(() => {
+  mockPermissions({ [PrisonerAdjudicationsPermission.read]: true })
   app = appWithAllRoutes({ production: false }, { reportedAdjudicationsService, punishmentsService })
 
   reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
@@ -62,10 +69,8 @@ describe('GET /active-punishments', () => {
   })
 
   it('should not show punishments when the user may not view the prisoner', () => {
-    const deniedApp = appWithAllRoutes(
-      { production: false },
-      { reportedAdjudicationsService, punishmentsService, permissionsService: mockPermissionsService(false) },
-    )
+    mockPermissions({ [PrisonerAdjudicationsPermission.read]: false })
+    const deniedApp = appWithAllRoutes({ production: false }, { reportedAdjudicationsService, punishmentsService })
 
     return request(deniedApp)
       .get(adjudicationUrls.activePunishments.urls.start('G7234VB'))

--- a/server/routes/activePunishments/activePunishments.test.ts
+++ b/server/routes/activePunishments/activePunishments.test.ts
@@ -6,6 +6,7 @@ import adjudicationUrls from '../../utils/urlGenerator'
 import TestData from '../testutils/testData'
 import PunishmentsService from '../../services/punishmentsService'
 import { PunishmentMeasurement, PunishmentType } from '../../data/PunishmentResult'
+import { mockPermissionsService } from '../testutils/mockPermissions'
 
 jest.mock('../../services/reportedAdjudicationsService.ts')
 jest.mock('../../services/punishmentsService.ts')
@@ -57,6 +58,23 @@ describe('GET /active-punishments', () => {
       .expect('Content-Type', /html/)
       .expect(response => {
         expect(response.text).toContain('James Smith’s active punishments')
+      })
+  })
+
+  it('should not show punishments when the user may not view the prisoner', () => {
+    const deniedApp = appWithAllRoutes(
+      { production: false },
+      { reportedAdjudicationsService, punishmentsService, permissionsService: mockPermissionsService(false) },
+    )
+
+    return request(deniedApp)
+      .get(adjudicationUrls.activePunishments.urls.start('G7234VB'))
+      .expect(403)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('James Smith')
+        expect(punishmentsService.getActivePunishmentsByOffender).not.toHaveBeenCalled()
       })
   })
 })

--- a/server/routes/activePunishments/index.ts
+++ b/server/routes/activePunishments/index.ts
@@ -1,4 +1,9 @@
 import express, { RequestHandler, Router } from 'express'
+import {
+  PermissionsService,
+  PrisonerAdjudicationsPermission,
+  prisonerPermissionsGuard,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 import ActivePunishments from './activePunishments'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
@@ -8,14 +13,20 @@ import PunishmentsService from '../../services/punishmentsService'
 export default function adjudicationHistoryRoutes({
   reportedAdjudicationsService,
   punishmentsService,
+  permissionsService,
 }: {
   reportedAdjudicationsService: ReportedAdjudicationsService
   punishmentsService: PunishmentsService
+  permissionsService: PermissionsService
 }): Router {
   const router = express.Router()
   const activePunishmentsRoute = new ActivePunishments(reportedAdjudicationsService, punishmentsService)
 
-  const get = (path: string, handler: RequestHandler) => router.get(path, handler)
+  const guard = prisonerPermissionsGuard(permissionsService, {
+    requestDependentOn: [PrisonerAdjudicationsPermission.read],
+  })
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, guard, handler)
   get(adjudicationUrls.adjudicationHistory.matchers.start, activePunishmentsRoute.view)
 
   return router

--- a/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.test.ts
+++ b/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.test.ts
@@ -1,16 +1,22 @@
 import { Express } from 'express'
 import request from 'supertest'
+import { PrisonerAdjudicationsPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import appWithAllRoutes from '../testutils/appSetup'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import DecisionTreeService from '../../services/decisionTreeService'
 import PunishmentsService from '../../services/punishmentsService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import TestData from '../testutils/testData'
-import { mockPermissionsService } from '../testutils/mockPermissions'
+import mockPermissions from '../testutils/mockPermissions'
 
 jest.mock('../../services/reportedAdjudicationsService.ts')
 jest.mock('../../services/decisionTreeService.ts')
 jest.mock('../../services/punishmentsService.ts')
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib', () => ({
+  ...jest.requireActual('@ministryofjustice/hmpps-prison-permissions-lib'),
+  isGranted: jest.fn(),
+  prisonerPermissionsGuard: jest.fn(),
+}))
 
 const testData = new TestData()
 const reportedAdjudicationsService = new ReportedAdjudicationsService(
@@ -25,16 +31,13 @@ const punishmentsService = new PunishmentsService(null, null) as jest.Mocked<Pun
 
 const url = adjudicationUrls.prisonerReportConsolidated.urls.view('G7234VB', 'MDI-100001')
 
-const buildApp = (granted: boolean): Express =>
-  appWithAllRoutes(
+const buildApp = (granted: boolean): Express => {
+  mockPermissions({ [PrisonerAdjudicationsPermission.read]: granted })
+  return appWithAllRoutes(
     { production: false },
-    {
-      reportedAdjudicationsService,
-      decisionTreeService,
-      punishmentsService,
-      permissionsService: mockPermissionsService(granted),
-    },
+    { reportedAdjudicationsService, decisionTreeService, punishmentsService },
   )
+}
 
 beforeEach(() => {
   reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(

--- a/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.test.ts
+++ b/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.test.ts
@@ -1,0 +1,79 @@
+import { Express } from 'express'
+import request from 'supertest'
+import appWithAllRoutes from '../testutils/appSetup'
+import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
+import DecisionTreeService from '../../services/decisionTreeService'
+import PunishmentsService from '../../services/punishmentsService'
+import adjudicationUrls from '../../utils/urlGenerator'
+import TestData from '../testutils/testData'
+import { mockPermissionsService } from '../testutils/mockPermissions'
+
+jest.mock('../../services/reportedAdjudicationsService.ts')
+jest.mock('../../services/decisionTreeService.ts')
+jest.mock('../../services/punishmentsService.ts')
+
+const testData = new TestData()
+const reportedAdjudicationsService = new ReportedAdjudicationsService(
+  null,
+  null,
+  null,
+  null,
+  null,
+) as jest.Mocked<ReportedAdjudicationsService>
+const decisionTreeService = new DecisionTreeService(null, null, null, null, null) as jest.Mocked<DecisionTreeService>
+const punishmentsService = new PunishmentsService(null, null) as jest.Mocked<PunishmentsService>
+
+const url = adjudicationUrls.prisonerReportConsolidated.urls.view('G7234VB', 'MDI-100001')
+
+const buildApp = (granted: boolean): Express =>
+  appWithAllRoutes(
+    { production: false },
+    {
+      reportedAdjudicationsService,
+      decisionTreeService,
+      punishmentsService,
+      permissionsService: mockPermissionsService(granted),
+    },
+  )
+
+beforeEach(() => {
+  reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
+    testData.prisonerResultSummary({ offenderNo: 'G7234VB', firstName: 'James', lastName: 'Smith' }),
+  )
+  reportedAdjudicationsService.getReportedAdjudicationDetails.mockResolvedValue({
+    reportedAdjudication: testData.reportedAdjudication({ chargeNumber: 'MDI-100001', prisonerNumber: 'G7234VB' }),
+  })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('GET consolidated adjudication view - access control', () => {
+  it('should not show the adjudication when the user may not view the prisoner', () => {
+    return request(buildApp(false))
+      .get(url)
+      .expect(403)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('Adjudication for charge MDI-100001')
+        expect(reportedAdjudicationsService.getReportedAdjudicationDetails).not.toHaveBeenCalled()
+      })
+  })
+
+  it('should not show an adjudication belonging to a different prisoner', () => {
+    reportedAdjudicationsService.getReportedAdjudicationDetails.mockResolvedValue({
+      reportedAdjudication: testData.reportedAdjudication({ chargeNumber: 'MDI-100001', prisonerNumber: 'A1234AA' }),
+    })
+
+    return request(buildApp(true))
+      .get(url)
+      .expect(403)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('Adjudication for charge MDI-100001')
+      })
+  })
+})

--- a/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.ts
+++ b/server/routes/adjudicationConsolidatedView/adjudicationConsolidatedView.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express'
 import ReportedAdjudicationsService, { ConvertedEvidence } from '../../services/reportedAdjudicationsService'
-import UserService from '../../services/userService'
 import { PrisonerResultSummary } from '../../services/placeOnReportService'
+import renderForbidden from '../../utils/renderForbidden'
 import DecisionTreeService, { IncidentAndOffences } from '../../services/decisionTreeService'
 import { ReportedAdjudication, ReportedAdjudicationStatus } from '../../data/ReportedAdjudicationResult'
 import { DraftAdjudication } from '../../data/DraftAdjudicationResult'
@@ -14,7 +14,6 @@ import {
   PunishmentDataWithSchedule,
   flattenPunishments,
 } from '../../data/PunishmentResult'
-import { hasAnyRole } from '../../utils/utils'
 
 type PageData = {
   prisoner: PrisonerResultSummary
@@ -42,13 +41,11 @@ type PageData = {
   quashed: boolean
   chargeProved: boolean
   corrupted: boolean
-  forbidden?: boolean
 }
 
 export default class AdjudicationConsolidatedView {
   constructor(
     private readonly reportedAdjudicationsService: ReportedAdjudicationsService,
-    private readonly userService: UserService,
     private readonly decisionTreeService: DecisionTreeService,
     private readonly punishmentsService: PunishmentsService,
   ) {}
@@ -70,7 +67,6 @@ export default class AdjudicationConsolidatedView {
       quashed,
       chargeProved,
       corrupted,
-      forbidden,
     } = pageData
     res.render(`pages/adjudicationConsolidatedView.njk`, {
       prisonerNumber: prisoner.prisonerNumber,
@@ -91,7 +87,6 @@ export default class AdjudicationConsolidatedView {
       quashed,
       chargeProved,
       corrupted,
-      forbidden,
     })
   }
 
@@ -99,8 +94,10 @@ export default class AdjudicationConsolidatedView {
     const { chargeNumber, prisonerNumber } = req.params
     const { user } = res.locals
     const activeCaseLoadId = req.query.agency as string
-    let forbidden = false
 
+    // The permissions guard has already proved the user may see this prisoner. It cannot know the
+    // charge belongs to them though, so still refuse a chargeNumber that resolves to someone else -
+    // this is the defence against tampering with the agency query param / charge number.
     const prisoner = await this.reportedAdjudicationsService.getPrisonerDetails(prisonerNumber, user)
     const { reportedAdjudication } = await this.reportedAdjudicationsService.getReportedAdjudicationDetails(
       chargeNumber,
@@ -108,12 +105,8 @@ export default class AdjudicationConsolidatedView {
       activeCaseLoadId,
     )
 
-    if (prisoner.agencyId !== user.meta.caseLoadId) {
-      const userRoles = await this.userService.getUserRoles(user.token)
-      forbidden = !hasAnyRole(['GLOBAL_SEARCH'], userRoles)
-    }
     if (prisoner.prisonerNumber !== reportedAdjudication.prisonerNumber) {
-      forbidden = true
+      return renderForbidden(res, prisoner.prisonerNumber)
     }
 
     const { reviewData, evidence, offence, prisonerReportDetails, transferBannerInfo } = await this.getInfoForReport(
@@ -142,7 +135,6 @@ export default class AdjudicationConsolidatedView {
       quashed,
       chargeProved,
       corrupted,
-      forbidden,
     })
   }
 

--- a/server/routes/adjudicationConsolidatedView/index.ts
+++ b/server/routes/adjudicationConsolidatedView/index.ts
@@ -1,33 +1,41 @@
 import express, { RequestHandler, Router } from 'express'
+import {
+  PermissionsService,
+  PrisonerAdjudicationsPermission,
+  prisonerPermissionsGuard,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 import AdjudicationConsolidatedView from './adjudicationConsolidatedView'
 
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
-import UserService from '../../services/userService'
 import DecisionTreeService from '../../services/decisionTreeService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import PunishmentsService from '../../services/punishmentsService'
 
 export default function adjudicationConsolidatedViewRoutes({
   reportedAdjudicationsService,
-  userService,
   decisionTreeService,
   punishmentsService,
+  permissionsService,
 }: {
   reportedAdjudicationsService: ReportedAdjudicationsService
-  userService: UserService
   decisionTreeService: DecisionTreeService
   punishmentsService: PunishmentsService
+  permissionsService: PermissionsService
 }): Router {
   const router = express.Router()
 
   const adjudicationConsolidatedViewRoute = new AdjudicationConsolidatedView(
     reportedAdjudicationsService,
-    userService,
     decisionTreeService,
     punishmentsService,
   )
-  const get = (path: string, handler: RequestHandler) => router.get(path, handler)
+
+  const guard = prisonerPermissionsGuard(permissionsService, {
+    requestDependentOn: [PrisonerAdjudicationsPermission.read],
+  })
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, guard, handler)
 
   get(adjudicationUrls.prisonerReportConsolidated.matchers.view, adjudicationConsolidatedViewRoute.view)
 

--- a/server/routes/adjudicationHistory/adjudicationHistory.test.ts
+++ b/server/routes/adjudicationHistory/adjudicationHistory.test.ts
@@ -4,6 +4,7 @@ import appWithAllRoutes from '../testutils/appSetup'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import TestData from '../testutils/testData'
+import { mockPermissionsService } from '../testutils/mockPermissions'
 
 jest.mock('../../services/reportedAdjudicationsService.ts')
 
@@ -90,6 +91,24 @@ describe('GET /adjudication-history', () => {
         expect(response.text).toContain('Awaiting review')
         expect(response.text).toContain('Date of discovery: 20/11/2021 - 13:30')
         expect(response.text).toContain('Happened at: Moorland (HMP)')
+      })
+  })
+
+  it('should not show the history when the user may not view the prisoner', () => {
+    const deniedApp = appWithAllRoutes(
+      { production: false },
+      { reportedAdjudicationsService, permissionsService: mockPermissionsService(false) },
+    )
+
+    return request(deniedApp)
+      .get(adjudicationUrls.adjudicationHistory.urls.start('G7234VB'))
+      .expect(403)
+      .expect('Content-Type', /html/)
+      .expect(response => {
+        expect(response.text).toContain('You do not have permission to view people outside of your establishment')
+        expect(response.text).not.toContain('MDI-100001')
+        expect(reportedAdjudicationsService.getAdjudicationHistory).not.toHaveBeenCalled()
+        expect(reportedAdjudicationsService.getUniqueListOfAgenciesForPrisoner).not.toHaveBeenCalled()
       })
   })
 })

--- a/server/routes/adjudicationHistory/adjudicationHistory.test.ts
+++ b/server/routes/adjudicationHistory/adjudicationHistory.test.ts
@@ -1,12 +1,18 @@
 import { Express } from 'express'
 import request from 'supertest'
+import { PrisonerAdjudicationsPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import appWithAllRoutes from '../testutils/appSetup'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import adjudicationUrls from '../../utils/urlGenerator'
 import TestData from '../testutils/testData'
-import { mockPermissionsService } from '../testutils/mockPermissions'
+import mockPermissions from '../testutils/mockPermissions'
 
 jest.mock('../../services/reportedAdjudicationsService.ts')
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib', () => ({
+  ...jest.requireActual('@ministryofjustice/hmpps-prison-permissions-lib'),
+  isGranted: jest.fn(),
+  prisonerPermissionsGuard: jest.fn(),
+}))
 
 const testData = new TestData()
 const reportedAdjudicationsService = new ReportedAdjudicationsService(
@@ -20,6 +26,7 @@ const reportedAdjudicationsService = new ReportedAdjudicationsService(
 let app: Express
 
 beforeEach(() => {
+  mockPermissions({ [PrisonerAdjudicationsPermission.read]: true })
   app = appWithAllRoutes({ production: false }, { reportedAdjudicationsService })
 
   reportedAdjudicationsService.getPrisonerDetails.mockResolvedValue(
@@ -95,10 +102,8 @@ describe('GET /adjudication-history', () => {
   })
 
   it('should not show the history when the user may not view the prisoner', () => {
-    const deniedApp = appWithAllRoutes(
-      { production: false },
-      { reportedAdjudicationsService, permissionsService: mockPermissionsService(false) },
-    )
+    mockPermissions({ [PrisonerAdjudicationsPermission.read]: false })
+    const deniedApp = appWithAllRoutes({ production: false }, { reportedAdjudicationsService })
 
     return request(deniedApp)
       .get(adjudicationUrls.adjudicationHistory.urls.start('G7234VB'))

--- a/server/routes/adjudicationHistory/adjudicationHistory.ts
+++ b/server/routes/adjudicationHistory/adjudicationHistory.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import mojPaginationFromPageResponse, { pageRequestFrom } from '../../utils/mojPagination/pagination'
-import { formatDateForDatePicker, hasAnyRole } from '../../utils/utils'
+import { formatDateForDatePicker } from '../../utils/utils'
 import { ReportedAdjudication } from '../../data/ReportedAdjudicationResult'
 import { ApiPageResponse } from '../../data/ApiData'
 import adjudicationUrls from '../../utils/urlGenerator'
@@ -18,13 +18,9 @@ import {
 import { EstablishmentInformation, FormError } from '../../@types/template'
 import { PrisonerResultSummary } from '../../services/placeOnReportService'
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
-import UserService from '../../services/userService'
 
 export default class AdjudicationHistoryRoutes {
-  constructor(
-    private readonly reportedAdjudicationsService: ReportedAdjudicationsService,
-    private readonly userService: UserService,
-  ) {}
+  constructor(private readonly reportedAdjudicationsService: ReportedAdjudicationsService) {}
 
   private renderView = async (
     req: Request,
@@ -34,7 +30,6 @@ export default class AdjudicationHistoryRoutes {
     errors: FormError[],
     prisoner: PrisonerResultSummary,
     uniqueListOfAgenciesForPrisoner: Array<EstablishmentInformation>,
-    forbidden?: boolean,
   ): Promise<void> => {
     res.render(`pages/adjudicationHistory.njk`, {
       prisonerNumber: req.params.prisonerNumber,
@@ -51,7 +46,6 @@ export default class AdjudicationHistoryRoutes {
       errors,
       maxDate: formatDateForDatePicker(new Date().toISOString(), 'short'),
       uniqueListOfAgenciesForPrisoner,
-      forbidden,
     })
   }
 
@@ -61,13 +55,6 @@ export default class AdjudicationHistoryRoutes {
     const uiFilter = fillInAdjudicationHistoryDefaults(uiAdjudicationHistoryFilterFromRequest(req))
     const filter = adjudicationHistoryFilterFromUiFilter(uiFilter)
     const prisoner = await this.reportedAdjudicationsService.getPrisonerDetails(prisonerNumber, user)
-    const activeCaseLoadId = user.meta.caseLoadId
-    let forbidden = false
-
-    if (prisoner.agencyId !== activeCaseLoadId) {
-      const roles = await this.userService.getUserRoles(user.token)
-      forbidden = !hasAnyRole(['GLOBAL_SEARCH'], roles)
-    }
 
     const uniqueListOfAgenciesForPrisoner = await this.reportedAdjudicationsService.getUniqueListOfAgenciesForPrisoner(
       prisonerNumber,
@@ -80,7 +67,7 @@ export default class AdjudicationHistoryRoutes {
       pageRequestFrom(20, +req.query.pageNumber || 1),
       res.locals.user,
     )
-    return this.renderView(req, res, uiFilter, results, [], prisoner, uniqueListOfAgenciesForPrisoner, forbidden)
+    return this.renderView(req, res, uiFilter, results, [], prisoner, uniqueListOfAgenciesForPrisoner)
   }
 
   submit = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/adjudicationHistory/index.ts
+++ b/server/routes/adjudicationHistory/index.ts
@@ -1,24 +1,32 @@
 import express, { RequestHandler, Router } from 'express'
+import {
+  PermissionsService,
+  PrisonerAdjudicationsPermission,
+  prisonerPermissionsGuard,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 import AdjudicationHistory from './adjudicationHistory'
 
 import ReportedAdjudicationsService from '../../services/reportedAdjudicationsService'
 import adjudicationUrls from '../../utils/urlGenerator'
-import UserService from '../../services/userService'
 
 export default function adjudicationHistoryRoutes({
   reportedAdjudicationsService,
-  userService,
+  permissionsService,
 }: {
   reportedAdjudicationsService: ReportedAdjudicationsService
-  userService: UserService
+  permissionsService: PermissionsService
 }): Router {
   const router = express.Router()
 
-  const adjudicationHistoryRoute = new AdjudicationHistory(reportedAdjudicationsService, userService)
+  const adjudicationHistoryRoute = new AdjudicationHistory(reportedAdjudicationsService)
 
-  const get = (path: string, handler: RequestHandler) => router.get(path, handler)
-  const post = (path: string, handler: RequestHandler) => router.post(path, handler)
+  const guard = prisonerPermissionsGuard(permissionsService, {
+    requestDependentOn: [PrisonerAdjudicationsPermission.read],
+  })
+
+  const get = (path: string, handler: RequestHandler) => router.get(path, guard, handler)
+  const post = (path: string, handler: RequestHandler) => router.post(path, guard, handler)
 
   get(adjudicationUrls.adjudicationHistory.matchers.start, adjudicationHistoryRoute.view)
   post(adjudicationUrls.adjudicationHistory.matchers.start, adjudicationHistoryRoute.submit)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -127,6 +127,7 @@ export default function routes(
     punishmentsService,
     chartApiService,
     createOnBehalfOfSessionService,
+    permissionsService,
   }: Services,
 ): Router {
   router.use(
@@ -156,7 +157,7 @@ export default function routes(
   )
   router.use(adjudicationUrls.confirmedOnReport.root, confirmedOnReportRoutes({ reportedAdjudicationsService }))
   router.use(adjudicationUrls.taskList.root, taskListRoutes({ placeOnReportService }))
-  router.use('/prisoner', prisonerRoutes({ placeOnReportService }))
+  router.use('/prisoner', prisonerRoutes({ placeOnReportService, permissionsService }))
   router.use(adjudicationUrls.searchForPrisoner.root, prisonerSearchRoutes({ userService }))
   router.use(adjudicationUrls.selectPrisoner.root, prisonerSelectRoutes({ prisonerSearchService, userService }))
   router.use(adjudicationUrls.selectAssociatedPrisoner.root, selectAssociatedPrisonerRoutes({ prisonerSearchService }))
@@ -512,19 +513,19 @@ export default function routes(
   )
   router.use(
     adjudicationUrls.adjudicationHistory.root,
-    adjudicationHistoryRoutes({ reportedAdjudicationsService, userService }),
+    adjudicationHistoryRoutes({ reportedAdjudicationsService, permissionsService }),
   )
   router.use(
     adjudicationUrls.activePunishments.root,
-    activePunishmentsRoutes({ reportedAdjudicationsService, punishmentsService }),
+    activePunishmentsRoutes({ reportedAdjudicationsService, punishmentsService, permissionsService }),
   )
   router.use(
     adjudicationUrls.prisonerReportConsolidated.root,
     adjudicationConsolidatedViewRoutes({
       reportedAdjudicationsService,
-      userService,
       decisionTreeService,
       punishmentsService,
+      permissionsService,
     }),
   )
 

--- a/server/routes/prisonerRoutes.test.ts
+++ b/server/routes/prisonerRoutes.test.ts
@@ -1,16 +1,24 @@
 import { Express } from 'express'
 import request from 'supertest'
 import { Readable } from 'stream'
+import { PrisonerAdjudicationsPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import appWithAllRoutes from './testutils/appSetup'
 import PlaceOnReportService from '../services/placeOnReportService'
-import { mockPermissionsService } from './testutils/mockPermissions'
+import mockPermissions from './testutils/mockPermissions'
 
 jest.mock('../services/placeOnReportService.ts')
+jest.mock('@ministryofjustice/hmpps-prison-permissions-lib', () => ({
+  ...jest.requireActual('@ministryofjustice/hmpps-prison-permissions-lib'),
+  isGranted: jest.fn(),
+  prisonerPermissionsGuard: jest.fn(),
+}))
 
 const placeOnReportService = new PlaceOnReportService(null, null, null) as jest.Mocked<PlaceOnReportService>
 
-const buildApp = (granted: boolean): Express =>
-  appWithAllRoutes({ production: false }, { placeOnReportService, permissionsService: mockPermissionsService(granted) })
+const buildApp = (granted: boolean): Express => {
+  mockPermissions({ [PrisonerAdjudicationsPermission.read]: granted })
+  return appWithAllRoutes({ production: false }, { placeOnReportService })
+}
 
 afterEach(() => jest.resetAllMocks())
 

--- a/server/routes/prisonerRoutes.test.ts
+++ b/server/routes/prisonerRoutes.test.ts
@@ -1,0 +1,38 @@
+import { Express } from 'express'
+import request from 'supertest'
+import { Readable } from 'stream'
+import appWithAllRoutes from './testutils/appSetup'
+import PlaceOnReportService from '../services/placeOnReportService'
+import { mockPermissionsService } from './testutils/mockPermissions'
+
+jest.mock('../services/placeOnReportService.ts')
+
+const placeOnReportService = new PlaceOnReportService(null, null, null) as jest.Mocked<PlaceOnReportService>
+
+const buildApp = (granted: boolean): Express =>
+  appWithAllRoutes({ production: false }, { placeOnReportService, permissionsService: mockPermissionsService(granted) })
+
+afterEach(() => jest.resetAllMocks())
+
+describe('GET /prisoner/:prisonerNumber/image', () => {
+  it('serves the prisoner image when the user may view the prisoner', () => {
+    placeOnReportService.getPrisonerImage.mockResolvedValue(Readable.from(Buffer.from('image-bytes')))
+
+    return request(buildApp(true))
+      .get('/prisoner/G7234VB/image')
+      .expect(200)
+      .expect('Content-Type', /image\/jpeg/)
+      .expect(() => {
+        expect(placeOnReportService.getPrisonerImage).toHaveBeenCalledWith('G7234VB', expect.anything())
+      })
+  })
+
+  it('serves the placeholder without fetching the image when the user may not view the prisoner', () => {
+    return request(buildApp(false))
+      .get('/prisoner/G7234VB/image')
+      .expect(200)
+      .expect(() => {
+        expect(placeOnReportService.getPrisonerImage).not.toHaveBeenCalled()
+      })
+  })
+})

--- a/server/routes/prisonerRoutes.ts
+++ b/server/routes/prisonerRoutes.ts
@@ -1,26 +1,48 @@
 import path from 'path'
-import express, { Router } from 'express'
+import express, { Response, Router } from 'express'
+import {
+  PermissionsService,
+  PrisonerAdjudicationsPermission,
+  isGranted,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 import PlaceOnReportService from '../services/placeOnReportService'
 
 export default function prisonerRoutes({
   placeOnReportService,
+  permissionsService,
 }: {
   placeOnReportService: PlaceOnReportService
+  permissionsService: PermissionsService
 }): Router {
   const router = express.Router()
 
-  router.get('/:prisonerNumber/image', async (req, res, next) => {
-    placeOnReportService
-      .getPrisonerImage(req.params.prisonerNumber, res.locals.user)
-      .then(data => {
-        res.type('image/jpeg')
-        data.pipe(res)
+  const sendPlaceholder = (res: Response) => {
+    const placeHolder = path.join(process.cwd(), '/assets/images/image-missing.jpg')
+    res.sendFile(placeHolder)
+  }
+
+  router.get('/:prisonerNumber/image', async (req, res) => {
+    const { prisonerNumber } = req.params
+    try {
+      // This is not an HTML page so it must not 403 - fall back to the placeholder the .catch()
+      // below already serves when the user may not see this prisoner's adjudication data.
+      const prisoner = await permissionsService.getPrisonerDetails(prisonerNumber)
+      const permissions = permissionsService.getPrisonerPermissions({
+        user: res.locals.user,
+        prisoner,
+        requestDependentOn: [PrisonerAdjudicationsPermission.read],
       })
-      .catch(() => {
-        const placeHolder = path.join(process.cwd(), '/assets/images/image-missing.jpg')
-        res.sendFile(placeHolder)
-      })
+      if (!isGranted(PrisonerAdjudicationsPermission.read, permissions)) {
+        return sendPlaceholder(res)
+      }
+
+      const data = await placeOnReportService.getPrisonerImage(prisonerNumber, res.locals.user)
+      res.type('image/jpeg')
+      return data.pipe(res)
+    } catch {
+      return sendPlaceholder(res)
+    }
   })
 
   return router

--- a/server/routes/standardRouter.ts
+++ b/server/routes/standardRouter.ts
@@ -3,6 +3,7 @@ import csurf from 'csurf'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from '../middleware/populateCurrentUser'
+import mapUserForPrisonPermissions from '../middleware/mapUserForPrisonPermissions'
 import type UserService from '../services/userService'
 
 const testMode = process.env.NODE_ENV === 'test'
@@ -12,6 +13,7 @@ export default function standardRouter(userService: UserService): Router {
 
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
+  router.use(mapUserForPrisonPermissions())
 
   // CSRF protection
   if (!testMode) {

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -25,6 +25,7 @@ import type { ApplicationInfo } from '../../applicationInfo'
 import ChartApiService from '../../services/chartApiService'
 import CreateOnBehalfOfSessionService from '../createOnBehalfOf/createOnBehalfOfSessionService'
 import FrontendComponentService from '../../services/frontendComponentService'
+import { mockPermissionsService } from './mockPermissions'
 
 const testAppInfo: ApplicationInfo = {
   productId: 'DPS001',
@@ -147,6 +148,7 @@ export default function appWithAllRoutes(
       chartApiService: {} as ChartApiService,
       createOnBehalfOfSessionService: {} as CreateOnBehalfOfSessionService,
       frontendComponentService: {} as FrontendComponentService,
+      permissionsService: mockPermissionsService(),
       ...overrides,
     }),
     production,

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -25,7 +25,7 @@ import type { ApplicationInfo } from '../../applicationInfo'
 import ChartApiService from '../../services/chartApiService'
 import CreateOnBehalfOfSessionService from '../createOnBehalfOf/createOnBehalfOfSessionService'
 import FrontendComponentService from '../../services/frontendComponentService'
-import { mockPermissionsService } from './mockPermissions'
+import { stubPermissionsService } from './mockPermissions'
 
 const testAppInfo: ApplicationInfo = {
   productId: 'DPS001',
@@ -148,7 +148,7 @@ export default function appWithAllRoutes(
       chartApiService: {} as ChartApiService,
       createOnBehalfOfSessionService: {} as CreateOnBehalfOfSessionService,
       frontendComponentService: {} as FrontendComponentService,
-      permissionsService: mockPermissionsService(),
+      permissionsService: stubPermissionsService(),
       ...overrides,
     }),
     production,

--- a/server/routes/testutils/mockPermissions.ts
+++ b/server/routes/testutils/mockPermissions.ts
@@ -1,0 +1,29 @@
+import { PermissionsService, PrisonerAdjudicationsPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
+
+/**
+ * Builds the minimal PrisonerPermissions shape that the library's isGranted() reads for the
+ * adjudications read permission (path: domainGroups.prisonerSpecific.prisonerAdjudications.<perm>).
+ */
+export const adjudicationsPermissions = (granted: boolean) => ({
+  domainGroups: {
+    prisonerSpecific: {
+      prisonerAdjudications: {
+        [PrisonerAdjudicationsPermission.read]: granted,
+      },
+    },
+  },
+})
+
+/**
+ * A stand-in PermissionsService for route tests. getPrisonerPermissions returns a granted or denied
+ * adjudications permission so the prisonerPermissionsGuard lets the request through or rejects it,
+ * without touching prisoner-search.
+ */
+export const mockPermissionsService = (
+  granted = true,
+  prisoner: unknown = { prisonerNumber: 'G7234VB', prisonId: 'MDI' },
+): PermissionsService =>
+  ({
+    getPrisonerDetails: jest.fn().mockResolvedValue(prisoner),
+    getPrisonerPermissions: jest.fn().mockReturnValue(adjudicationsPermissions(granted)),
+  }) as unknown as PermissionsService

--- a/server/routes/testutils/mockPermissions.ts
+++ b/server/routes/testutils/mockPermissions.ts
@@ -1,29 +1,48 @@
-import { PermissionsService, PrisonerAdjudicationsPermission } from '@ministryofjustice/hmpps-prison-permissions-lib'
+import {
+  isGranted,
+  PermissionsService,
+  PrisonerPermission,
+  prisonerPermissionsGuard,
+} from '@ministryofjustice/hmpps-prison-permissions-lib'
 
 /**
- * Builds the minimal PrisonerPermissions shape that the library's isGranted() reads for the
- * adjudications read permission (path: domainGroups.prisonerSpecific.prisonerAdjudications.<perm>).
+ * Test helper recommended by the permissions library
+ * (https://github.com/ministryofjustice/hmpps-prison-permissions-lib/blob/main/readme/mocking.md):
+ * mock the library's isGranted and prisonerPermissionsGuard rather than depending on the internal
+ * shape of the permissions object.
+ *
+ * Each test file that uses this must first mock the library, keeping the real enums/PermissionsService
+ * but replacing the two functions:
+ *
+ *   jest.mock('@ministryofjustice/hmpps-prison-permissions-lib', () => ({
+ *     ...jest.requireActual('@ministryofjustice/hmpps-prison-permissions-lib'),
+ *     isGranted: jest.fn(),
+ *     prisonerPermissionsGuard: jest.fn(),
+ *   }))
+ *
+ * Call mockPermissions(...) before building the app, since the guard middleware is created when the
+ * routes are wired.
  */
-export const adjudicationsPermissions = (granted: boolean) => ({
-  domainGroups: {
-    prisonerSpecific: {
-      prisonerAdjudications: {
-        [PrisonerAdjudicationsPermission.read]: granted,
-      },
+export default function mockPermissions(permissions: Partial<Record<PrisonerPermission, boolean>>): void {
+  ;(isGranted as jest.MockedFunction<typeof isGranted>).mockImplementation(perm => permissions[perm] ?? false)
+  ;(prisonerPermissionsGuard as jest.MockedFunction<typeof prisonerPermissionsGuard>).mockImplementation(
+    (_service, options) => async (_req, _res, next) => {
+      const denied = options.requestDependentOn.filter(perm => !permissions[perm])
+      return denied.length ? next(permissionDeniedError(denied)) : next()
     },
-  },
-})
+  )
+}
 
-/**
- * A stand-in PermissionsService for route tests. getPrisonerPermissions returns a granted or denied
- * adjudications permission so the prisonerPermissionsGuard lets the request through or rejects it,
- * without touching prisoner-search.
- */
-export const mockPermissionsService = (
-  granted = true,
-  prisoner: unknown = { prisonerNumber: 'G7234VB', prisonId: 'MDI' },
-): PermissionsService =>
+// Mimics the library's PrisonerPermissionError (which is not publicly exported) so the app's error
+// handler recognises it via deniedPermissionChecks and renders the forbidden page, not a generic 500.
+function permissionDeniedError(denied: PrisonerPermission[]): Error {
+  return Object.assign(new Error('Permission denied'), { status: 403, deniedPermissionChecks: denied })
+}
+
+// Minimal PermissionsService for the app harness. With the guard and isGranted mocked, its methods
+// are only reached by the prisoner image route, which just needs them not to throw.
+export const stubPermissionsService = (): PermissionsService =>
   ({
-    getPrisonerDetails: jest.fn().mockResolvedValue(prisoner),
-    getPrisonerPermissions: jest.fn().mockReturnValue(adjudicationsPermissions(granted)),
+    getPrisonerDetails: jest.fn().mockResolvedValue({}),
+    getPrisonerPermissions: jest.fn().mockReturnValue({}),
   }) as unknown as PermissionsService

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,4 +1,7 @@
+import { PermissionsService } from '@ministryofjustice/hmpps-prison-permissions-lib'
 import { dataAccess } from '../data'
+import config from '../config'
+import logger from '../../logger'
 import UserService from './userService'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import TokenStore from '../data/tokenStore'
@@ -76,6 +79,17 @@ const outcomesService = new OutcomesService()
 const punishmentsService = new PunishmentsService(hmppsAuthClient, hmppsManageUsersClient)
 const createOnBehalfOfSessionService = new CreateOnBehalfOfSessionService()
 const frontendComponentService = new FrontendComponentService(frontendComponentApiClient)
+
+// Shared HMPPS logic for "may this member of staff see this prisoner's adjudications?". The library
+// fetches prisoner data from prisoner-search itself using a system (client-credentials) token, which
+// the existing HmppsAuthClient already provides and caches. The system client must hold
+// ROLE_VIEW_PRISONER_DATA for these calls to succeed.
+const permissionsService = PermissionsService.create({
+  prisonerSearchConfig: config.apis.prisonerSearch,
+  authenticationClient: { getToken: (username?: string) => hmppsAuthClient.getSystemClientToken(username) },
+  logger,
+})
+
 const { applicationInfo } = dataAccess()
 
 export const services = {
@@ -95,6 +109,7 @@ export const services = {
   chartApiService,
   createOnBehalfOfSessionService,
   frontendComponentService,
+  permissionsService,
 }
 
 export type Services = typeof services

--- a/server/utils/renderForbidden.ts
+++ b/server/utils/renderForbidden.ts
@@ -1,0 +1,11 @@
+import { Response } from 'express'
+
+/**
+ * Renders the "you may not view people outside your establishment" page with a 403 status. Used both
+ * by the error handler (when the prison-permissions guard denies a request) and directly by routes
+ * that need to refuse a request after the guard has run (e.g. a charge that belongs to another
+ * prisoner). Keeps the deny experience identical wherever it is triggered.
+ */
+export default function renderForbidden(res: Response, prisonerNumber?: string): void {
+  res.status(403).render('pages/forbidden', { prisonerNumber })
+}

--- a/server/views/pages/adjudicationConsolidatedView.njk
+++ b/server/views/pages/adjudicationConsolidatedView.njk
@@ -29,19 +29,14 @@
       href: digitalPrisonServiceUrl
     },
     {
-      text: 'Adjudications' if forbidden else prisoner.displayName,
-      href: '/place-a-prisoner-on-report' if forbidden else prisonerProfileServiceUrl + '/prisoner/' + prisonerNumber
+      text: prisoner.displayName,
+      href: prisonerProfileServiceUrl + '/prisoner/' + prisonerNumber
     }
     ],
     classes: "govuk-!-display-none-print"
   }) }}
 {% endblock %}
 {% block content %}
-{% if forbidden %}
-    <h1 class="govuk-heading-l">You do not have permission to view people outside of your establishment.</h1>
-    <p class="govuk-body">You need extra permission to be able to view and create reports for people who are not in your establishment.</p>
-    <p class="govuk-body">Contact a local system administrator (LSA) in your establishment to discuss the permission you need.</p>
-{% else %}
   {# Report details #}
   <div class="govuk-grid-row">
     {% if reportedAdjudication.overrideAgencyId and transferBannerContent %}
@@ -125,5 +120,4 @@
       </div>
     {% endif %}
   </div>
-{% endif %}
 {% endblock %}

--- a/server/views/pages/adjudicationHistory.njk
+++ b/server/views/pages/adjudicationHistory.njk
@@ -20,8 +20,8 @@
       href: digitalPrisonServiceUrl
     },
     {
-      text: 'Adjudications' if forbidden else prisoner.displayName,
-      href: '/place-a-prisoner-on-report' if forbidden else prisonerProfileServiceUrl + '/prisoner/' + prisonerNumber
+      text: prisoner.displayName,
+      href: prisonerProfileServiceUrl + '/prisoner/' + prisonerNumber
     }
     ],
     classes: "govuk-!-display-none-print"
@@ -36,11 +36,6 @@
       }) }}
   {% endif %}
 
-  {% if forbidden %}
-    <h1 class="govuk-heading-l">You do not have permission to view people outside of your establishment.</h1>
-    <p class="govuk-body">You need extra permission to be able to view and create reports for people who are not in your establishment.</p>
-    <p class="govuk-body">Contact a local system administrator (LSA) in your establishment to discuss the permission you need.</p>
-  {% else %}
   <h1 class="govuk-heading-l" data-qa="title">{{ prisoner.friendlyName | possessive }} adjudication history</h1>
 
   <div class="govuk-grid-row">
@@ -51,5 +46,4 @@
       {% include '../partials/adjudicationHistoryList.njk' %}
     </div>
   </div>
-  {% endif %}
 {% endblock %}

--- a/server/views/pages/forbidden.njk
+++ b/server/views/pages/forbidden.njk
@@ -1,0 +1,31 @@
+{% extends "../partials/layout.njk" %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+{% set title = 'You do not have permission to view this page' %}
+
+{% block pageTitle %}
+  {{ title }} - Digital Prison Services
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    collapseOnMobile: true,
+    items: [
+      {
+        text: "Digital Prison Services",
+        href: digitalPrisonServiceUrl
+      },
+      {
+        text: "Adjudications",
+        href: '/place-a-prisoner-on-report'
+      }
+    ],
+    classes: "govuk-!-display-none-print"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l" data-qa="forbidden">You do not have permission to view people outside of your establishment.</h1>
+  <p class="govuk-body">You need extra permission to be able to view and create reports for people who are not in your establishment.</p>
+  <p class="govuk-body">Contact a local system administrator (LSA) in your establishment to discuss the permission you need.</p>
+{% endblock %}


### PR DESCRIPTION
## Why

A user could read any prisoner's adjudication data by hand-editing the URL. The frontend calls the adjudications API with a system token and tells it which caseload to act as via the `Active-Caseload` header, so this can only be enforced in the frontend.

Rather than a bespoke check, this adopts the shared **`@ministryofjustice/hmpps-prison-permissions-lib`** — the same library the Prisoner Profile and DPS micro-frontend components use — so the rules are consistent everywhere: the link to an adjudication on the profile and a hand-typed adjudications URL now obey identical rules.

> Supersedes #1467 (the earlier bespoke, caseloads-only approach). That PR can be closed.

## Permission used

Gates on `PrisonerAdjudicationsPermission.read` — the adjudications-specific permission the profile uses. Its rule:

- Prisoner in **any** of the user's caseloads → allowed
- **`GLOBAL_SEARCH` alone does not grant access** (consistent with the IR-1785 intent to drop it)
- **POM / Reception** users get cross-caseload access, plus restricted-patient / transferring / released handling — the nationally-agreed rule the profile already applies

## What changed

- `PermissionsService` constructed in the service registry (reuses the existing system-token client — no new auth dependency)
- Middleware maps `res.locals.user` onto the shape the library reads (`authSource`, `caseLoads`, `activeCaseLoadId`, `userRoles`)
- `prisonerPermissionsGuard` on adjudication history, active punishments and the consolidated report view
- Prisoner image route performs the equivalent check manually and serves the placeholder image on denial (it must not 403)
- Consolidated view keeps its charge-ownership check (the `?agency=` tamper defence the guard can't cover)
- Denials render a shared forbidden page via the error handler — which previously redirected **every** 403 to sign-out
- Removed the old `forbidden` / `GLOBAL_SEARCH` fetch-then-hide code and template branches

## ⚠️ Behaviour change

`GLOBAL_SEARCH` users lose out-of-caseload adjudication access; **POM and Reception** users gain cross-caseload access. This matches the Prisoner Profile.

## ⚠️ Deploy prerequisite

The adjudications **system client must hold `ROLE_VIEW_PRISONER_DATA`** (helm / cloud-platform change) so the library can read hmpps-prisoner-search. Without it, every request is denied.

## Testing

- Unit tests: grant/deny cases for all four surfaces + the user-shape adapter middleware (1173 passing)
- Lint and typecheck clean
- Integration (Cypress) specs updated with a prisoner-search stub for the guard — **please confirm the Cypress run in CI**
- Manual end-to-end against real prisoner-search still to be done once `ROLE_VIEW_PRISONER_DATA` is granted in the environment